### PR TITLE
Feat/diagnostic metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "eventhub" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   EventhubInstanceName = < Name of EventHub Instance >
   EventhubNamespace = < Name of Eventhub Namespace >
   EventhubResourceGroupName = < Name of Eventhub ResourceGroup >
@@ -49,6 +50,7 @@ module "bloblstorage" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   BlobContainerName = < Blob Container Name>
   BlobContainerStorageAccount = < Blob Container Storage Account Name >
   BlobContainerResourceGroupName = < Blob Container Resource Group Name>
@@ -69,6 +71,7 @@ module "storagequeue" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   StorageQueueName = < Name of the StorageQueue >
   StorageQueueStorageAccount = < Name of the StorageQueue Storage Account >
   StorageQueueResourceGroupName = < Name of the StorageQueue Resource Group >

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "diagnosticmetrics" {
   CoralogixRegion = "Europe"
   CoralogixPrivateKey = < Private Key >
   CoralogixApplication = "Azure"
-  CoralogixSubsystem = "EventHub"
+  CoralogixSubsystem = "DiagnosticMetrics"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
   EventhubInstanceName = < Name of EventHub Instance >

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ module "storagequeue" {
 }
 ```
 
+`diagnosticmetrics`:
+
+```hcl
+module "diagnosticmetrics" {
+  source = "coralogix/azure/coralogix//modules/diagnosticmetrics"
+
+  CoralogixRegion = "Europe"
+  CoralogixPrivateKey = < Private Key >
+  CoralogixApplication = "Azure"
+  CoralogixSubsystem = "EventHub"
+  FunctionResourceGroupName = < Function ResourceGroup Name >
+  FunctionStorageAccountName = < Function StorageAccount Name >
+  EventhubInstanceName = < Name of EventHub Instance >
+  EventhubNamespace = < Name of Eventhub Namespace >
+  EventhubResourceGroupName = < Name of Eventhub ResourceGroup >
+}
+```
+
 
 ## Authors
 

--- a/modules/blobstorage/README.md
+++ b/modules/blobstorage/README.md
@@ -33,6 +33,7 @@ module "bloblstorage" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   BlobContainerName = < Blob Container Name>
   BlobContainerStorageAccount = < Blob Container Storage Account Name >
   BlobContainerResourceGroupName = < Blob Container Resource Group Name>
@@ -64,6 +65,7 @@ module "bloblstorage" {
 | <a name="input_CoralogixSubsystem"></a> [CoralogixSubsystem](#input\_CoralogixSubsystem) | The subsystem name of your application | `string` | n/a | yes |
 | <a name="input_FunctionResourceGroupName"></a> [FunctionResourceGroupName](#input\_FunctionResourceGroupName) | The name of the resource group into which to deploy the Function App | `string` | n/a | yes |
 | <a name="input_FunctionStorageAccountName"></a> [FunctionStorageAccountName](#input\_FunctionStorageAccountName) | The name of the storage account that the Function App will use | `string` | n/a | yes |
+| <a name="input_FunctionAppServicePlanType"></a> [FunctionAppServicePlanType](#input\_FunctionAppServicePlanType) | The type of the App Service Plan to use for the Function App. Choose Premium if you need vNet support. | `string` | `Consumption` | yes |
 | <a name="input_BlobContainerName"></a> [BlobContainerName](#input\_BlobContainerName) | The name of the Blob Container | `string` | n/a | yes
 | <a name="input_BlobContainerStorageAccount"></a> [BlobContainerStorageAccount](#input\_BlobContainerStorageAccount) | The name of the Storage Account containing the Blob Container | `string` | n/a | yes
 | <a name="input_BlobContainerResourceGroupName"></a> [BlobContainerResourceGroupName](#input\_BlobContainerResourceGroupName) | The name of the resource group that contains the Storage Account | `string` | n/a | yes

--- a/modules/blobstorage/main.tf
+++ b/modules/blobstorage/main.tf
@@ -7,6 +7,7 @@ locals {
     Singapore = "ingress.coralogixsg.com"
     US        = "ingress.coralogix.us"
   }
+  sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"
 }
 
 resource "random_string" "this" {
@@ -59,12 +60,12 @@ data "azurerm_storage_account" "functionSA" {
   resource_group_name = var.FunctionResourceGroupName
 }
 
-resource "azurerm_service_plan" "consumption-plan" {
+resource "azurerm_service_plan" "service-plan" {
   name                = "${local.function_name}-plan"
   resource_group_name = var.FunctionResourceGroupName
   location            = data.azurerm_resource_group.functionRG.location
   os_type             = "Linux"
-  sku_name            = "Y1"
+  sku_name            = local.sku
 }
 
 resource "azurerm_application_insights" "crx-appinsights" {
@@ -80,7 +81,7 @@ resource "azurerm_linux_function_app" "blobstorage-function" {
   location                    = data.azurerm_resource_group.functionRG.location
   storage_account_name        = var.FunctionStorageAccountName
   storage_account_access_key  = data.azurerm_storage_account.functionSA.primary_access_key
-  service_plan_id             = azurerm_service_plan.consumption-plan.id
+  service_plan_id             = azurerm_service_plan.service-plan.id
   functions_extension_version = "~4"
   site_config {
     application_insights_key               = azurerm_application_insights.crx-appinsights.instrumentation_key

--- a/modules/blobstorage/variables.tf
+++ b/modules/blobstorage/variables.tf
@@ -33,6 +33,16 @@ variable "FunctionStorageAccountName" {
   type        = string
 }
 
+variable "FunctionAppServicePlanType" {
+  description = "The type of the App Service Plan to use for the Function App"
+  type        = string
+  default     = "Consumption"
+  validation {
+    condition     = contains(["Consumption", "Premium"], var.FunctionAppServicePlanType)
+    error_message = "The function app service plan type must be on of these values: [Consumption, Premium]."
+  }
+}
+
 variable "BlobContainerName" {
   description = "The name of the Blob Container."
   type        = string

--- a/modules/diagnosticmetrics/README.md
+++ b/modules/diagnosticmetrics/README.md
@@ -1,0 +1,69 @@
+# Diagnostic Metrics
+
+Manage the function app which reads "Disagnostic Settings" metrics from an `eventhub` and sends them to your *Coralogix* account.
+
+## Pre-requisites
+
+A Resource Group and Storage Account to be used by your Function App must be provided as inputs to the Terraform module.
+
+The EventHub Namespace and Instance must be pre-existing, though a SAS Policy will be created by the Terraform module to allow LISTEN access to the EventHub Instance by the Function App.
+
+Metrics configured in a resource's "Diagnostic Settings" must be submitted to the above EventHub. Presently, only "allMetrics" metrics categories are supported. We are working on adding support for additional Azure Metrics categories.
+
+## Usage
+
+```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      version = "~> 3.50"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+module "diagnosticmetrics" {
+  source = "coralogix/azure/coralogix//modules/diagnosticmetrics"
+
+  CoralogixRegion = "Europe"
+  CoralogixPrivateKey = < Private Key >
+  CoralogixApplication = "Azure"
+  CoralogixSubsystem = "DiagnosticMetrics"
+  FunctionResourceGroupName = < Function ResourceGroup Name >
+  FunctionStorageAccountName = < Function StorageAccount Name >
+  EventhubInstanceName = < Name of EventHub Instance >
+  EventhubNamespace = < Name of Eventhub Namespace >
+  EventhubResourceGroupName = < Name of Eventhub ResourceGroup >
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.50.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`Europe`, `Europe2`, `India`, `Singapore`, `US`] | `string` | `Europe` | no |
+| <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
+| <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application | `string` | n/a | yes |
+| <a name="input_CoralogixSubsystem"></a> [CoralogixSubsystem](#input\_CoralogixSubsystem) | The subsystem name of your application | `string` | n/a | yes |
+| <a name="input_FunctionResourceGroupName"></a> [FunctionResourceGroupName](#input\_FunctionResourceGroupName) | The name of the resource group into which to deploy the Function App | `string` | n/a | yes |
+| <a name="input_FunctionStorageAccountName"></a> [FunctionStorageAccountName](#input\_FunctionStorageAccountName) | The name of the storage account that the Function App will use | `string` | n/a | yes |
+| <a name="input_EventhubInstanceName"></a> [EventhubInstanceName](#input\_EventhubInstanceName) | The name of the EventHub Instance | `string` | n/a | yes |
+| <a name="input_EventhubNamespace"></a> [EventhubNamespace](#input\_EventhubNamespace) | The name of the EventHub Namespace | `string` | n/a | yes |
+| <a name="input_EventhubResourceGroupName"></a> [EventhubResourceGroupName](#input\_EventhubResourceGroupName) | The name of the resource group that the eventhub belong to. | `string` | n/a | yes |

--- a/modules/diagnosticmetrics/main.tf
+++ b/modules/diagnosticmetrics/main.tf
@@ -1,0 +1,100 @@
+locals {
+  function_name = join("-", ["DiagnosticMetrics", random_string.this.result])
+  coralogix_regions = {
+    Europe    = "ingress.coralogix.com"
+    Europe2   = "ingress.eu2.coralogix.com"
+    India     = "ingress.coralogix.in"
+    Singapore = "ingress.coralogixsg.com"
+    US        = "ingress.coralogix.us"
+  }
+}
+
+resource "random_string" "this" {
+  length  = 13
+  special = false
+  lower   = true
+  upper   = false
+}
+
+# ------------------------------------------------ Eventhub ------------------------------------------------
+data "azurerm_eventhub_namespace" "eventhub-namespace" {
+  name                = var.EventhubNamespace
+  resource_group_name = var.EventhubResourceGroupName
+}
+
+data "azurerm_resource_group" "eventhub-resourcegroup" {
+  name = var.EventhubResourceGroupName
+}
+
+data "azurerm_eventhub" "EventhubInstance" {
+  name                = var.EventhubInstanceName
+  namespace_name      = var.EventhubNamespace
+  resource_group_name = var.EventhubResourceGroupName
+}
+
+resource "azurerm_eventhub_authorization_rule" "instance_sas" {
+  name                = "${local.function_name}-SAS"
+  namespace_name      = var.EventhubNamespace
+  eventhub_name       = var.EventhubInstanceName
+  resource_group_name = var.EventhubResourceGroupName
+  listen              = true
+  send                = false
+  manage              = false
+}
+
+# ------------------------------------------------ Function App ------------------------------------------------
+data "azurerm_resource_group" "functionRG" {
+  name = var.FunctionResourceGroupName
+}
+
+data "azurerm_storage_account" "functionSA" {
+  name                = var.FunctionStorageAccountName
+  resource_group_name = var.FunctionResourceGroupName
+}
+
+resource "azurerm_service_plan" "consumption-plan" {
+  name                = "${local.function_name}-plan"
+  resource_group_name = var.FunctionResourceGroupName
+  location            = data.azurerm_resource_group.functionRG.location
+  os_type             = "Linux"
+  sku_name            = "Y1"
+}
+
+resource "azurerm_application_insights" "crx-appinsights" {
+  name                = "${local.function_name}-appinsights"
+  resource_group_name = var.FunctionResourceGroupName
+  location            = data.azurerm_resource_group.functionRG.location
+  application_type    = "web"
+}
+
+resource "azurerm_linux_function_app" "eventhub-function" {
+  name                        = local.function_name
+  resource_group_name         = var.FunctionResourceGroupName
+  location                    = data.azurerm_resource_group.functionRG.location
+  storage_account_name        = var.FunctionStorageAccountName
+  storage_account_access_key  = data.azurerm_storage_account.functionSA.primary_access_key
+  service_plan_id             = azurerm_service_plan.consumption-plan.id
+  functions_extension_version = "~4"
+  site_config {
+    application_insights_key               = azurerm_application_insights.crx-appinsights.instrumentation_key
+    application_insights_connection_string = azurerm_application_insights.crx-appinsights.connection_string
+    application_stack {
+      node_version = 18
+    }
+  }
+  app_settings = {
+    # Environment variable
+    CORALOGIX_APP_NAME       = var.CoralogixApplication
+    CORALOGIX_PRIVATE_KEY    = var.CoralogixPrivateKey
+    CORALOGIX_SUB_SYSTEM     = var.CoralogixSubsystem
+    CORALOGIX_URL            = "https://${local.coralogix_regions[var.CoralogixRegion]}/azure/events/v1"
+    EVENTHUB_CONNECT_STRING  = azurerm_eventhub_authorization_rule.instance_sas.primary_connection_string
+    EVENTHUB_INSTANCE_NAME   = var.EventhubInstanceName
+    WEBSITE_RUN_FROM_PACKAGE = "https://coralogix-public.s3.eu-west-1.amazonaws.com/azure-functions-repo/DiagnosticMetrics.zip"
+  }
+}
+
+# ------------------------------------------------ Output ------------------------------------------------
+output "RegionCheck" {
+  value = data.azurerm_resource_group.functionRG.location == data.azurerm_resource_group.eventhub-resourcegroup.location ? "[Info] Azure Function WAS deployed in the same region as the EventHub" : "[Notice] Azure Function WAS NOT deployed in the same region as the EventHub"
+}

--- a/modules/diagnosticmetrics/variables.tf
+++ b/modules/diagnosticmetrics/variables.tf
@@ -1,0 +1,49 @@
+variable "CoralogixRegion" {
+  description = "The Coralogix location region, possible options are [Europe, Europe2, India, Singapore, US]"
+  type        = string
+  validation {
+    condition     = contains(["Europe", "Europe2", "India", "Singapore", "US"], var.CoralogixRegion)
+    error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US]."
+  }
+}
+
+variable "CoralogixPrivateKey" {
+  description = "The Coralogix private key which is used to validate your authenticity"
+  type        = string
+  sensitive   = true
+}
+
+variable "CoralogixApplication" {
+  description = "The name of your application"
+  type        = string
+}
+
+variable "CoralogixSubsystem" {
+  description = "The subsystem name of your application"
+  type        = string
+}
+
+variable "FunctionResourceGroupName" {
+  description = "The name of the resource group into which to deploy the Function App"
+  type        = string
+}
+
+variable "FunctionStorageAccountName" {
+  description = "The name of the storage account that the Function App will use"
+  type        = string
+}
+
+variable "EventhubResourceGroupName" {
+  description = "The name of the resource group that the eventhub belong to"
+  type        = string
+}
+
+variable "EventhubNamespace" {
+  description = "The name of the EventHub Namespace."
+  type        = string
+}
+
+variable "EventhubInstanceName" {
+  description = "The name of the EventHub Instance."
+  type        = string
+}

--- a/modules/diagnosticmetrics/versions.tf
+++ b/modules/diagnosticmetrics/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.50"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
+    }
+  }
+}
+
+

--- a/modules/eventhub/README.md
+++ b/modules/eventhub/README.md
@@ -33,6 +33,7 @@ module "eventhub" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   EventhubInstanceName = < Name of EventHub Instance >
   EventhubNamespace = < Name of Eventhub Namespace >
   EventhubResourceGroupName = < Name of Eventhub ResourceGroup >
@@ -62,6 +63,7 @@ module "eventhub" {
 | <a name="input_CoralogixSubsystem"></a> [CoralogixSubsystem](#input\_CoralogixSubsystem) | The subsystem name of your application | `string` | n/a | yes |
 | <a name="input_FunctionResourceGroupName"></a> [FunctionResourceGroupName](#input\_FunctionResourceGroupName) | The name of the resource group into which to deploy the Function App | `string` | n/a | yes |
 | <a name="input_FunctionStorageAccountName"></a> [FunctionStorageAccountName](#input\_FunctionStorageAccountName) | The name of the storage account that the Function App will use | `string` | n/a | yes |
+| <a name="input_FunctionAppServicePlanType"></a> [FunctionAppServicePlanType](#input\_FunctionAppServicePlanType) | The type of the App Service Plan to use for the Function App. Choose Premium if you need vNet support. | `string` | `Consumption` | yes |
 | <a name="input_EventhubInstanceName"></a> [EventhubInstanceName](#input\_EventhubInstanceName) | The name of the EventHub Instance | `string` | n/a | yes |
 | <a name="input_EventhubNamespace"></a> [EventhubNamespace](#input\_EventhubNamespace) | The name of the EventHub Namespace | `string` | n/a | yes |
 | <a name="input_EventhubResourceGroupName"></a> [EventhubResourceGroupName](#input\_EventhubResourceGroupName) | The name of the resource group that the eventhub belong to. | `string` | n/a | yes |

--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -7,6 +7,7 @@ locals {
     Singapore = "ingress.coralogixsg.com"
     US        = "ingress.coralogix.us"
   }
+  sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"
 }
 
 resource "random_string" "this" {
@@ -52,12 +53,12 @@ data "azurerm_storage_account" "functionSA" {
   resource_group_name = var.FunctionResourceGroupName
 }
 
-resource "azurerm_service_plan" "consumption-plan" {
+resource "azurerm_service_plan" "service-plan" {
   name                = "${local.function_name}-plan"
   resource_group_name = var.FunctionResourceGroupName
   location            = data.azurerm_resource_group.functionRG.location
   os_type             = "Linux"
-  sku_name            = "Y1"
+  sku_name            = local.sku
 }
 
 resource "azurerm_application_insights" "crx-appinsights" {
@@ -73,7 +74,7 @@ resource "azurerm_linux_function_app" "eventhub-function" {
   location                    = data.azurerm_resource_group.functionRG.location
   storage_account_name        = var.FunctionStorageAccountName
   storage_account_access_key  = data.azurerm_storage_account.functionSA.primary_access_key
-  service_plan_id             = azurerm_service_plan.consumption-plan.id
+  service_plan_id             = azurerm_service_plan.service-plan.id
   functions_extension_version = "~4"
   site_config {
     application_insights_key               = azurerm_application_insights.crx-appinsights.instrumentation_key

--- a/modules/eventhub/variables.tf
+++ b/modules/eventhub/variables.tf
@@ -33,6 +33,16 @@ variable "FunctionStorageAccountName" {
   type        = string
 }
 
+variable "FunctionAppServicePlanType" {
+  description = "The type of the App Service Plan to use for the Function App"
+  type        = string
+  default     = "Consumption"
+  validation {
+    condition     = contains(["Consumption", "Premium"], var.FunctionAppServicePlanType)
+    error_message = "The function app service plan type must be on of these values: [Consumption, Premium]."
+  }
+}
+
 variable "EventhubResourceGroupName" {
   description = "The name of the resource group that the eventhub belong to"
   type        = string

--- a/modules/storagequeue/README.md
+++ b/modules/storagequeue/README.md
@@ -33,6 +33,7 @@ module "storagequeue" {
   CoralogixSubsystem = "EventHub"
   FunctionResourceGroupName = < Function ResourceGroup Name >
   FunctionStorageAccountName = < Function StorageAccount Name >
+  FunctionAppServicePlanType = "Consumption"
   StorageQueueName = < Name of the StorageQueue >
   StorageQueueStorageAccount = < Name of the StorageQueue Storage Account >
   StorageQueueResourceGroupName = < Name of the StorageQueue Resource Group >
@@ -62,6 +63,7 @@ module "storagequeue" {
 | <a name="input_CoralogixSubsystem"></a> [CoralogixSubsystem](#input\_CoralogixSubsystem) | The subsystem name of your application | `string` | n/a | yes |
 | <a name="input_FunctionResourceGroupName"></a> [FunctionResourceGroupName](#input\_FunctionResourceGroupName) | The name of the resource group into which to deploy the Function App | `string` | n/a | yes |
 | <a name="input_FunctionStorageAccountName"></a> [FunctionStorageAccountName](#input\_FunctionStorageAccountName) | The name of the storage account that the Function App will use | `string` | n/a | yes |
+| <a name="input_FunctionAppServicePlanType"></a> [FunctionAppServicePlanType](#input\_FunctionAppServicePlanType) | The type of the App Service Plan to use for the Function App. Choose Premium if you need vNet support. | `string` | `Consumption` | yes |
 | <a name="input_StorageQueueName"></a> [StorageQueueName](#input\_StorageQueueName) | The name of the StorageQueue | `string` | n/a | yes |
 | <a name="input_StorageQueueStorageAccount"></a> [StorageQueueStorageAccount](#input\_StorageQueueStorageAccount) | The name of the Storage Account containing the StorageQueue | `string` | n/a | yes |
 | <a name="input_StorageQueueResourceGroupName"></a> [StorageQueueResourceGroupName](#input\_StorageQueueResourceGroupName) | The name of the resource group that contains the Storage Account | `string` | n/a | yes |

--- a/modules/storagequeue/main.tf
+++ b/modules/storagequeue/main.tf
@@ -7,6 +7,7 @@ locals {
     Singapore = "ingress.coralogixsg.com"
     US        = "ingress.coralogix.us"
   }
+    sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"
 }
 
 resource "random_string" "this" {
@@ -36,12 +37,12 @@ data "azurerm_storage_account" "functionSA" {
   resource_group_name = var.FunctionResourceGroupName
 }
 
-resource "azurerm_service_plan" "consumption-plan" {
+resource "azurerm_service_plan" "service-plan" {
   name                = "${local.function_name}-plan"
   resource_group_name = var.FunctionResourceGroupName
   location            = data.azurerm_resource_group.functionRG.location
   os_type             = "Linux"
-  sku_name            = "Y1"
+  sku_name            = local.sku
 }
 
 resource "azurerm_application_insights" "crx-appinsights" {
@@ -57,7 +58,7 @@ resource "azurerm_linux_function_app" "storagequeue-function" {
   location                    = data.azurerm_resource_group.functionRG.location
   storage_account_name        = var.FunctionStorageAccountName
   storage_account_access_key  = data.azurerm_storage_account.functionSA.primary_access_key
-  service_plan_id             = azurerm_service_plan.consumption-plan.id
+  service_plan_id             = azurerm_service_plan.service-plan.id
   functions_extension_version = "~4"
   site_config {
     application_insights_key               = azurerm_application_insights.crx-appinsights.instrumentation_key

--- a/modules/storagequeue/variables.tf
+++ b/modules/storagequeue/variables.tf
@@ -33,6 +33,16 @@ variable "FunctionStorageAccountName" {
   type        = string
 }
 
+variable "FunctionAppServicePlanType" {
+  description = "The type of the App Service Plan to use for the Function App"
+  type        = string
+  default     = "Consumption"
+  validation {
+    condition     = contains(["Consumption", "Premium"], var.FunctionAppServicePlanType)
+    error_message = "The function app service plan type must be on of these values: [Consumption, Premium]."
+  }
+}
+
 variable "StorageQueueName" {
   description = "The name of the StorageQueue."
   type        = string


### PR DESCRIPTION
This work supports the need to allow Premium service plans for vNet support for private storage account access.

New integration for sending Metrics from a resource's "Diagnostic Settings" to Coralogix.
