### PR TITLE
Add FunctionAppServicePlanType variable

### DIFF
--- a/modules/diagnosticdata/CHANGELOG.md
+++ b/modules/diagnosticdata/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## diagnosticdata
 
-###1.0.9 / 11 Jan 2024
+### 1.0.9 / 11 Jan 2024
 [Update] Add missing FunctionAppServicePlanType to variables.tf

--- a/modules/diagnosticdata/CHANGELOG.md
+++ b/modules/diagnosticdata/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
 ## diagnosticdata
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+1.0.9 - 11 Jan 2024
+[Update] Add missing FunctionAppServicePlanType to variables.tf

--- a/modules/diagnosticdata/CHANGELOG.md
+++ b/modules/diagnosticdata/CHANGELOG.md
@@ -2,5 +2,5 @@
 
 ## diagnosticdata
 
-1.0.9 - 11 Jan 2024
+###1.0.9 / 11 Jan 2024
 [Update] Add missing FunctionAppServicePlanType to variables.tf

--- a/modules/diagnosticdata/variables.tf
+++ b/modules/diagnosticdata/variables.tf
@@ -39,6 +39,16 @@ variable "FunctionStorageAccountName" {
   type        = string
 }
 
+variable "FunctionAppServicePlanType" {
+  description = "The type of the App Service Plan to use for the Function App"
+  type        = string
+  default     = "Consumption"
+  validation {
+    condition     = contains(["Consumption", "Premium"], var.FunctionAppServicePlanType)
+    error_message = "The function app service plan type must be on of these values: [Consumption, Premium]."
+  }
+}
+
 variable "EventhubResourceGroupName" {
   description = "The name of the resource group that the eventhub belong to"
   type        = string


### PR DESCRIPTION
Add FunctionAppServicePlanType variable to diagnosticdata module

# Description

Add the FunctionAppServicePlanType to the DiagnosticData module's variables.tf file.
CDS-974

# How Has This Been Tested?

No functional change to the TF modules, no testing performed.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)