### PR TITLE
E2E Tests: Stage 1

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,116 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      # Uncomment when ready for production
+      #   - master
+      - e2e-stage2
+    paths:
+      - "modules/storagequeue/**"
+      - "modules/eventhub/**"
+      - "modules/diagnosticdata/**"
+      - "modules/blobstorage/**"
+      - "modules/blobtootel/**"
+      - "tests/storagequeue/**"
+      - "tests/eventhub/**"
+      - "tests/diagnosticdata/**"
+      - "tests/blobstorage/**"
+      - "tests/blobtootel/**"
+# Uncomment when ready for production
+#   schedule:
+#     # Every morning 8am UTC
+#     - cron: "0 8 * * *"
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+      has-changes: ${{ steps.set-packages.outputs.has-changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        if: github.event_name != 'schedule'
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed packages
+        uses: dorny/paths-filter@v3
+        id: changes
+        if: github.event_name == 'push'
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            storagequeue:
+              - 'modules/storagequeue/**'
+              - 'tests/storagequeue/**'
+            eventhub:
+              - 'modules/eventhub/**'
+              - 'tests/eventhub/**'
+            diagnosticdata:
+              - 'modules/diagnosticdata/**'
+              - 'tests/diagnosticdata/**'
+            blobstorage:
+              - 'modules/blobstorage/**'
+              - 'tests/blobstorage/**'
+            blobtootel:
+              - 'modules/blobtootel/**'
+              - 'tests/blobtootel/**'
+
+      - name: Set packages matrix
+        id: set-packages
+        run: |
+          # Delete 2nd part of the if statement when enabling master/schedule
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref }}" == "refs/heads/e2e-stage2" ]]; then
+            echo 'packages=["storagequeue","eventhub","diagnosticdata","blobstorage","blobtootel"]' >> $GITHUB_OUTPUT
+            echo 'has-changes=true' >> $GITHUB_OUTPUT
+          else
+            packages='${{ steps.changes.outputs.changes }}'
+            echo "packages=$packages" >> $GITHUB_OUTPUT
+            if [[ "$packages" == "[]" ]] || [[ -z "$packages" ]]; then
+              echo 'has-changes=false' >> $GITHUB_OUTPUT
+            else
+              echo 'has-changes=true' >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  e2e:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.4"
+
+      - name: Setup Python (EventHub e2e)
+        if: matrix.package == 'eventhub'
+        run: pip install azure-eventhub
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+
+      - name: Run E2E test
+        working-directory: ./tests/${{ matrix.package }}
+        env:
+          OTEL_ENDPOINT: ${{ secrets.OTEL_ENDPOINT }}
+          CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
+          CORALOGIX_QUERY_API_KEY: ${{ secrets.CORALOGIX_QUERY_API_KEY }}
+          CORALOGIX_DIRECT_MODE: "true"
+        run: ./e2e.sh

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,18 @@
+# Terraform
+**/terraform/.terraform/
+**/terraform/.terraform.lock.hcl
+**/*.tfstate
+**/*.tfstate.*
+**/terraform/terraform.tfvars
+**/crash.log
+**/override.tf
+**/override.tf.json
+**/*_override.tf
+**/*_override.tf.json
+
+# E2E temp files
+.e2e-*.tmp
+*.tmp
+
+# ARM params (serverless-style; not used here but ignore if present)
+arm-params.json

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,75 @@
+# E2E tests for Terraform Coralogix Azure modules
+
+These tests validate the **terraform-coralogix-azure** modules by deploying each module (with the same parameters as the equivalent ARM templates in [coralogix-azure-serverless](https://github.com/coralogix/coralogix-azure-serverless)), triggering the function with a test payload, and verifying data in Coralogix. Unlike the serverless repo, deployment is done **entirely via Terraform** (no ARM): the test Terraform config provisions prerequisites and then calls the module under test. This ensures the **latest working version of the Terraform modules** is exercised.
+
+## Test suites
+
+| Directory        | Module        | Trigger                    | Verification        |
+|------------------|---------------|----------------------------|---------------------|
+| `storagequeue/` | StorageQueue  | Message in storage queue   | Logs count API      |
+| `eventhub/`     | EventHub      | Event sent to Event Hub    | Logs count API      |
+| `diagnosticdata/` | DiagnosticData | Blob uploads → diagnostic → Event Hub | Data usage (metrics) API |
+| `blobstorage/`  | BlobStorage (BlobViaEventGrid) | Blob upload → Event Grid | Logs count API      |
+| `blobtootel/`    | BlobToOtel    | Blob upload → Event Grid → Event Hub | Logs count API      |
+
+## Prerequisites
+
+- **Azure CLI** installed and logged in (`az login`), or service principal env vars for CI.
+- **Terraform** >= 1.7.4.
+- **jq** (for Coralogix API responses).
+- **Python 3** with `azure-eventhub` only for the **EventHub** test: `pip install -r eventhub/requirements.txt`.
+
+## Environment variables
+
+Set before running any e2e script:
+
+- **OTEL_ENDPOINT** (required) – Coralogix ingress base URL, e.g. `https://ingress.eu2.coralogix.com`.
+- **CORALOGIX_API_KEY** (required for all except BlobToOtel when using OTLP only) – Send your data / Private key for the function.
+- **CORALOGIX_QUERY_API_KEY** (optional) – For verification step (Data Usage read). Defaults to `CORALOGIX_API_KEY` if unset.
+
+Optional overrides (defaults are per-test):
+
+- **CORALOGIX_APPLICATION** – e.g. `azure`.
+- **CORALOGIX_SUBSYSTEM** – e.g. `storage-queue-e2e`, `eventhub-e2e`, etc.
+- **FUNCTION_APP_SERVICE_PLAN_TYPE** – `Consumption` or `Premium`.
+
+## Usage
+
+From the repo root or from each test directory:
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"
+export CORALOGIX_API_KEY="your-send-your-data-key"
+export CORALOGIX_QUERY_API_KEY="your-query-key"
+
+# Run a single test (from repo root)
+./tests/storagequeue/e2e.sh
+./tests/eventhub/e2e.sh
+./tests/diagnosticdata/e2e.sh
+./tests/blobstorage/e2e.sh
+./tests/blobtootel/e2e.sh
+```
+
+Each `e2e.sh`:
+
+1. Deploys Terraform (prereqs + module) in the test’s `terraform/` directory.
+2. Triggers the function (queue message, event, or blob upload).
+3. Waits and polls the Coralogix API until data is present (or times out).
+4. Deletes the resource group and clears Terraform state.
+
+## Difference from coralogix-azure-serverless e2e
+
+- **Serverless e2e**: Terraform only provisions prerequisites (e.g. RG, queue, Event Hub); the **ARM template** is deployed via `az deployment group create` to deploy the function.
+- **These e2e tests**: Terraform provisions prerequisites **and** calls the **Terraform module** (e.g. `module "storagequeue" { source = "../../modules/storagequeue" ... }`) with the same logical parameters as the ARM template. No ARM deployment. This tests the Terraform modules with the latest working version.
+
+## Optional: run check scripts only
+
+After a manual deploy, you can run the check scripts to verify logs/metrics without re-running the full e2e:
+
+- `storagequeue/check_logs.sh`
+- `eventhub/check_logs.sh`
+- `diagnosticdata/check_metrics.sh`
+- `blobstorage/check_logs.sh`
+- `blobtootel/check_logs.sh`
+
+Set `OTEL_ENDPOINT` and `CORALOGIX_QUERY_API_KEY` (or `CORALOGIX_API_KEY`) as above.

--- a/tests/blobstorage/check_logs.sh
+++ b/tests/blobstorage/check_logs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for BlobViaEventGrid E2E (app=azure, subsystem=blob-storage-eventgrid-e2e or blob-storage-logs).
+# Requires: CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT.
+
+if [[ -n "${CX_LOGS_COUNT_URL:-}" ]]; then
+  :
+elif [[ -n "${OTEL_ENDPOINT:-}" ]]; then
+  CX_API_HOST="${OTEL_ENDPOINT#*://}"
+  CX_API_HOST="${CX_API_HOST%%:*}"
+  CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+  CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+else
+  CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+fi
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYS)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/tests/blobstorage/e2e.sh
+++ b/tests/blobstorage/e2e.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# E2E test for BlobStorage (BlobViaEventGrid) Terraform module.
+#
+# Order of execution:
+#   1. Deploy Terraform (RG, StorageV2, container, Event Grid system topic, function storage, BlobStorage module).
+#   2. Upload a test blob to trigger Event Grid → function.
+#   3. Wait 30s, then poll Coralogix Get Logs Count API until count > 0.
+#   4. Clean up all resources.
+#
+# Prerequisites: Azure CLI, Terraform >= 1.7.4, jq.
+# Environment: OTEL_ENDPOINT, CORALOGIX_API_KEY; optional: CORALOGIX_QUERY_API_KEY, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+CUSTOM_DOMAIN="${OTEL_ENDPOINT#*://}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%/*}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%:*}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  cd "$TERRAFORM_DIR" || return 0
+  export TF_VAR_coralogix_custom_domain="${CUSTOM_DOMAIN:-}"
+  export TF_VAR_coralogix_private_key="${CORALOGIX_API_KEY:-}"
+  export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+  export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
+  export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+  terraform destroy -input=false -auto-approve 2>/dev/null || true
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Deploy Terraform (prereqs + module) ---
+log "Step 1: Deploying Terraform (RG, StorageV2, container, Event Grid system topic, BlobStorage module)..."
+cd "$TERRAFORM_DIR"
+export TF_VAR_coralogix_custom_domain="$CUSTOM_DOMAIN"
+export TF_VAR_coralogix_private_key="$CORALOGIX_API_KEY"
+export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
+export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+
+terraform init -input=false
+
+# Apply 1: create RG and prereqs only (-refresh=false so module data sources are not evaluated yet).
+log "Step 1a: Creating RG, storage, container, Event Grid system topic, function storage..."
+terraform apply -refresh=false -input=false -auto-approve \
+  -target=azurerm_resource_group.e2e \
+  -target=random_string.suffix \
+  -target=azurerm_storage_account.blob \
+  -target=azurerm_storage_container.logs \
+  -target=azurerm_eventgrid_system_topic.storage \
+  -target=azurerm_storage_account.function
+
+# Apply 2: full apply (BlobStorage module; data sources now find existing resources).
+log "Step 1b: Creating BlobStorage module..."
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME"
+
+# --- Step 2: Upload test blob to trigger Event Grid → function ---
+log "Step 2: Uploading test blob to trigger Event Grid and the function..."
+TEST_BLOB_NAME="e2e-test-$(date +%s).log"
+TEST_BLOB_FILE="${SCRIPT_DIR}/.e2e-test-payload.tmp"
+printf 'e2e test line 1\ne2e test line 2\ne2e test line 3\n' > "$TEST_BLOB_FILE"
+az storage blob upload \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --container-name "$CONTAINER_NAME" \
+  --name "$TEST_BLOB_NAME" \
+  --file "$TEST_BLOB_FILE" \
+  --type block \
+  --content-type "text/plain" \
+  --no-progress
+rm -f "$TEST_BLOB_FILE"
+
+log "Uploaded test blob: $CONTAINER_NAME/$TEST_BLOB_NAME"
+
+# --- Step 3: Verify logs in Coralogix (e2e uses blob-storage-logs in API filter to match function default) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+# BlobViaEventGrid function sends with subsystem from var (blob-storage-eventgrid-e2e); blobstorage module uses CORALOGIX_SUB_SYSTEM. Use same as we passed.
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 3: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYS)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 3: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 3: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 3: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 4: Clean up ---
+log "Step 4: Cleaning up resources..."
+trap - EXIT
+cd "$TERRAFORM_DIR"
+terraform destroy -input=false -auto-approve
+log "E2E test finished."

--- a/tests/blobstorage/e2e.sh
+++ b/tests/blobstorage/e2e.sh
@@ -37,7 +37,7 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   cd "$TERRAFORM_DIR" || return 0
-  export TF_VAR_coralogix_custom_domain="${CUSTOM_DOMAIN:-}"
+  export TF_VAR_otel_endpoint="${OTEL_ENDPOINT:-}"
   export TF_VAR_coralogix_private_key="${CORALOGIX_API_KEY:-}"
   export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
   export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
@@ -49,7 +49,7 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Deploy Terraform (prereqs + module) ---
 log "Step 1: Deploying Terraform (RG, StorageV2, container, Event Grid system topic, BlobStorage module)..."
 cd "$TERRAFORM_DIR"
-export TF_VAR_coralogix_custom_domain="$CUSTOM_DOMAIN"
+export TF_VAR_otel_endpoint="$OTEL_ENDPOINT"
 export TF_VAR_coralogix_private_key="$CORALOGIX_API_KEY"
 export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
 export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"

--- a/tests/blobstorage/terraform/main.tf
+++ b/tests/blobstorage/terraform/main.tf
@@ -1,0 +1,92 @@
+# E2E test: deploy Terraform BlobStorage (BlobViaEventGrid) module (same parameters as ARM).
+# Prereqs: RG, StorageV2 account, container, Event Grid system topic for the storage account, function storage.
+# The module creates the Event Grid subscription to the function.
+
+terraform {
+  required_version = ">= 1.7.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "blobviaeg-e2e"
+  location    = "eastus"
+}
+
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_storage_account" "blob" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "logs" {
+  name                  = "logs"
+  storage_account_name  = azurerm_storage_account.blob.name
+  container_access_type = "private"
+}
+
+# Event Grid system topic for the storage account (required by blobstorage module)
+resource "azurerm_eventgrid_system_topic" "storage" {
+  name                   = "cxEventGridTopic"
+  resource_group_name    = azurerm_resource_group.e2e.name
+  location               = azurerm_resource_group.e2e.location
+  source_arm_resource_id = azurerm_storage_account.blob.id
+  topic_type             = "Microsoft.Storage.StorageAccounts"
+}
+
+resource "azurerm_storage_account" "function" {
+  name                     = lower(replace("${local.name_prefix}fn${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+module "blobstorage" {
+  source = "../../../modules/blobstorage"
+
+  CoralogixRegion              = "Custom"
+  CustomDomain                 = var.coralogix_custom_domain
+  CoralogixPrivateKey         = var.coralogix_private_key
+  CoralogixApplication        = var.coralogix_application
+  CoralogixSubsystem          = var.coralogix_subsystem
+  FunctionResourceGroupName   = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName  = azurerm_storage_account.function.name
+  FunctionAppServicePlanType  = var.function_app_service_plan_type
+  BlobContainerName           = azurerm_storage_container.logs.name
+  BlobContainerStorageAccount = azurerm_storage_account.blob.name
+  BlobContainerResourceGroupName = azurerm_resource_group.e2e.name
+  EventGridSystemTopicName    = azurerm_eventgrid_system_topic.storage.name
+  NewlinePattern              = var.newline_pattern
+  DebugEnabled                = var.debug_enabled
+  EnableBlobMetadata          = var.enable_blob_metadata
+}

--- a/tests/blobstorage/terraform/main.tf
+++ b/tests/blobstorage/terraform/main.tf
@@ -74,8 +74,7 @@ resource "azurerm_storage_account" "function" {
 module "blobstorage" {
   source = "../../../modules/blobstorage"
 
-  CoralogixRegion              = "Custom"
-  CustomDomain                 = var.coralogix_custom_domain
+  OtelEndpoint                 = var.otel_endpoint
   CoralogixPrivateKey         = var.coralogix_private_key
   CoralogixApplication        = var.coralogix_application
   CoralogixSubsystem          = var.coralogix_subsystem

--- a/tests/blobstorage/terraform/main.tf
+++ b/tests/blobstorage/terraform/main.tf
@@ -74,18 +74,18 @@ resource "azurerm_storage_account" "function" {
 module "blobstorage" {
   source = "../../../modules/blobstorage"
 
-  OtelEndpoint                 = var.otel_endpoint
-  CoralogixPrivateKey         = var.coralogix_private_key
-  CoralogixApplication        = var.coralogix_application
-  CoralogixSubsystem          = var.coralogix_subsystem
-  FunctionResourceGroupName   = azurerm_resource_group.e2e.name
-  FunctionStorageAccountName  = azurerm_storage_account.function.name
-  FunctionAppServicePlanType  = var.function_app_service_plan_type
-  BlobContainerName           = azurerm_storage_container.logs.name
-  BlobContainerStorageAccount = azurerm_storage_account.blob.name
+  OtelEndpoint                   = var.otel_endpoint
+  CoralogixPrivateKey            = var.coralogix_private_key
+  CoralogixApplication           = var.coralogix_application
+  CoralogixSubsystem             = var.coralogix_subsystem
+  FunctionResourceGroupName      = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName     = azurerm_storage_account.function.name
+  FunctionAppServicePlanType     = var.function_app_service_plan_type
+  BlobContainerName              = azurerm_storage_container.logs.name
+  BlobContainerStorageAccount    = azurerm_storage_account.blob.name
   BlobContainerResourceGroupName = azurerm_resource_group.e2e.name
-  EventGridSystemTopicName    = azurerm_eventgrid_system_topic.storage.name
-  NewlinePattern              = var.newline_pattern
-  DebugEnabled                = var.debug_enabled
-  EnableBlobMetadata          = var.enable_blob_metadata
+  EventGridSystemTopicName       = azurerm_eventgrid_system_topic.storage.name
+  NewlinePattern                 = var.newline_pattern
+  DebugEnabled                   = var.debug_enabled
+  EnableBlobMetadata             = var.enable_blob_metadata
 }

--- a/tests/blobstorage/terraform/outputs.tf
+++ b/tests/blobstorage/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "resource_group_location" {
+  value = azurerm_resource_group.e2e.location
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.blob.name
+}
+
+output "storage_account_resource_group" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "blob_container_name" {
+  value = azurerm_storage_container.logs.name
+}
+
+output "storage_account_connection_string" {
+  value     = azurerm_storage_account.blob.primary_connection_string
+  sensitive = true
+}

--- a/tests/blobstorage/terraform/variables.tf
+++ b/tests/blobstorage/terraform/variables.tf
@@ -1,7 +1,7 @@
-variable "coralogix_custom_domain" {
-  description = "Coralogix ingress FQDN (e.g. ingress.eu2.coralogix.com), no protocol or path."
+variable "otel_endpoint" {
+  description = "OTLP endpoint URL (e.g. https://ingress.eu2.coralogix.com)."
   type        = string
-  default     = "" # Not used by destroy; set TF_VAR_* or -var for apply.
+  default     = "" # Not used by destroy; set TF_VAR_otel_endpoint or -var for apply.
 }
 
 variable "coralogix_private_key" {

--- a/tests/blobstorage/terraform/variables.tf
+++ b/tests/blobstorage/terraform/variables.tf
@@ -1,0 +1,42 @@
+variable "coralogix_custom_domain" {
+  description = "Coralogix ingress FQDN (e.g. ingress.eu2.coralogix.com), no protocol or path."
+  type        = string
+  default     = "" # Not used by destroy; set TF_VAR_* or -var for apply.
+}
+
+variable "coralogix_private_key" {
+  description = "Coralogix Send your data / Private key."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "coralogix_application" {
+  type    = string
+  default = "azure"
+}
+
+variable "coralogix_subsystem" {
+  type    = string
+  default = "blob-storage-eventgrid-e2e"
+}
+
+variable "function_app_service_plan_type" {
+  type    = string
+  default = "Consumption"
+}
+
+variable "newline_pattern" {
+  type    = string
+  default = "(?:\\r\\n|\\r|\\n)"
+}
+
+variable "debug_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "enable_blob_metadata" {
+  type    = bool
+  default = false
+}

--- a/tests/blobtootel/check_logs.sh
+++ b/tests/blobtootel/check_logs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for BlobToOtel E2E (app=azure, subsystem=blob-storage-logs or blob-storage-eventhub-e2e).
+# Requires: CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT.
+
+if [[ -n "${CX_LOGS_COUNT_URL:-}" ]]; then
+  :
+elif [[ -n "${OTEL_ENDPOINT:-}" ]]; then
+  CX_API_HOST="${OTEL_ENDPOINT#*://}"
+  CX_API_HOST="${CX_API_HOST%%:*}"
+  CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+  CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+else
+  CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+fi
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-logs}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYS)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/tests/blobtootel/e2e.sh
+++ b/tests/blobtootel/e2e.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# E2E test for BlobToOtel Terraform module.
+#
+# Order of execution:
+#   1. Deploy Terraform (RG, storage, container, Event Hub, Event Grid subscription, BlobToOtel module).
+#   2. Upload a test blob to trigger Event Grid → Event Hub → function.
+#   3. Wait 30s, then poll Coralogix Get Logs Count API until count > 0.
+#   4. Clean up all resources.
+#
+# Prerequisites: Azure CLI, Terraform >= 1.7.4, jq.
+# Environment: OTEL_ENDPOINT (required); optional: CORALOGIX_API_KEY, CORALOGIX_QUERY_API_KEY, CORALOGIX_DIRECT_MODE, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"   # for Step 3 verification
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+
+# BlobToOtel can run without Coralogix API key (OTLP to Coralogix endpoint); verification needs query key
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  cd "$TERRAFORM_DIR" || return 0
+  export TF_VAR_otel_endpoint="${OTEL_ENDPOINT:-}"
+  export TF_VAR_coralogix_direct_mode="${CORALOGIX_DIRECT_MODE:-false}"
+  export TF_VAR_coralogix_api_key="${CORALOGIX_API_KEY:-}"
+  export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+  export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"
+  export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+  export TF_VAR_prefix_filter="${PREFIX_FILTER:-NoFilter}"
+  export TF_VAR_suffix_filter="${SUFFIX_FILTER:-NoFilter}"
+  terraform destroy -input=false -auto-approve 2>/dev/null || true
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Deploy Terraform (prereqs + module) ---
+log "Step 1: Deploying Terraform (RG, storage, container, Event Hub, Event Grid subscription, BlobToOtel module)..."
+cd "$TERRAFORM_DIR"
+export TF_VAR_otel_endpoint="$OTEL_ENDPOINT"
+export TF_VAR_coralogix_direct_mode="${CORALOGIX_DIRECT_MODE:-false}"
+export TF_VAR_coralogix_api_key="${CORALOGIX_API_KEY:-}"
+export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"
+export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+export TF_VAR_prefix_filter="${PREFIX_FILTER:-NoFilter}"
+export TF_VAR_suffix_filter="${SUFFIX_FILTER:-NoFilter}"
+
+terraform init -input=false
+
+# Apply 1: create RG and prereqs only (-refresh=false so module data sources are not evaluated yet).
+log "Step 1a: Creating RG, storage, container, Event Hub..."
+terraform apply -refresh=false -input=false -auto-approve \
+  -target=azurerm_resource_group.e2e \
+  -target=random_string.suffix \
+  -target=azurerm_storage_account.blob \
+  -target=azurerm_storage_container.logs \
+  -target=azurerm_eventhub_namespace.ns \
+  -target=azurerm_eventhub.hub
+
+# Apply 2: full apply (Event Grid subscription + BlobToOtel module; data sources now find existing resources).
+log "Step 1b: Creating Event Grid subscription and BlobToOtel module..."
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME"
+
+# --- Step 2: Upload test blob to trigger function ---
+log "Step 2: Uploading test blob to trigger the function..."
+TEST_BLOB_NAME="e2e-test-$(date +%s).log"
+TEST_BLOB_FILE="${SCRIPT_DIR}/.e2e-test-payload.tmp"
+printf 'e2e test line 1\ne2e test line 2\ne2e test line 3\n' > "$TEST_BLOB_FILE"
+az storage blob upload \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --container-name "$CONTAINER_NAME" \
+  --name "$TEST_BLOB_NAME" \
+  --file "$TEST_BLOB_FILE" \
+  --type block \
+  --content-type "text/plain" \
+  --no-progress
+rm -f "$TEST_BLOB_FILE"
+
+log "Uploaded test blob: $CONTAINER_NAME/$TEST_BLOB_NAME"
+
+# --- Step 3: Verify logs in Coralogix (subsystem=blob-storage-logs from module default / e2e var) ---
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+if [[ -z "${CORALOGIX_QUERY_API_KEY:-}" ]]; then
+  log "Step 3: Skipping Coralogix verification (no CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY)."
+else
+  now_minus_10m() {
+    if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+      return
+    fi
+    date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+  }
+
+  fetch_logs_count() {
+    local from to
+    from=$(now_minus_10m)
+    to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+    curl -s -G "$CX_LOGS_COUNT_URL" \
+      --data-urlencode "date_range.fromDate=$from" \
+      --data-urlencode "date_range.toDate=$to" \
+      --data-urlencode "resolution=10m" \
+      --data-urlencode "filters.application=azure" \
+      --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+      --data-urlencode "subsystem_aggregation=true" \
+      -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+  }
+
+  log "Step 3: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYS)..."
+  sleep 30
+
+  attempt=0
+  while true; do
+    attempt=$((attempt + 1))
+    count=$(fetch_logs_count)
+    if [[ -n "$count" && "$count" -gt 0 ]]; then
+      log "Step 3: Logs verified in Coralogix (count=$count)."
+      break
+    fi
+    if [[ $attempt -ge 10 ]]; then
+      err "Step 3: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+      exit 1
+    fi
+    log "Step 3: No logs yet (attempt $attempt/10), retrying in 30s..."
+    sleep 30
+  done
+fi
+
+# --- Step 4: Clean up ---
+log "Step 4: Cleaning up resources..."
+trap - EXIT
+cd "$TERRAFORM_DIR"
+terraform destroy -input=false -auto-approve
+log "E2E test finished."

--- a/tests/blobtootel/terraform/main.tf
+++ b/tests/blobtootel/terraform/main.tf
@@ -1,0 +1,99 @@
+# E2E test: deploy Terraform BlobToOtel module (same parameters as ARM in coralogix-azure-serverless).
+# Prereqs: RG, storage account, container, Event Hub namespace + hub, Event Grid subscription (blob created → Event Hub).
+# The module creates the function app (and its own function storage and consumer group).
+
+terraform {
+  required_version = ">= 1.7.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "blobtootel-e2e"
+  location    = "eastus"
+}
+
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_storage_account" "blob" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+}
+
+resource "azurerm_storage_container" "logs" {
+  name                  = "logs"
+  storage_account_name   = azurerm_storage_account.blob.name
+  container_access_type = "private"
+}
+
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+resource "azurerm_eventhub" "hub" {
+  name                = "blob-events"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+# Route blob-created events from storage to Event Hub (triggers the function via module-created consumer group)
+resource "azurerm_eventgrid_event_subscription" "storage_to_eventhub" {
+  name                 = "${local.name_prefix}-storage-to-eh"
+  scope                = azurerm_storage_account.blob.id
+  eventhub_endpoint_id = azurerm_eventhub.hub.id
+  included_event_types  = ["Microsoft.Storage.BlobCreated"]
+}
+
+module "blobtootel" {
+  source = "../../../modules/blobtootel"
+
+  OtelEndpoint                  = var.otel_endpoint
+  CoralogixDirectMode            = var.coralogix_direct_mode
+  CoralogixApiKey               = var.coralogix_api_key
+  CoralogixApplication          = var.coralogix_application
+  CoralogixSubsystem            = var.coralogix_subsystem
+  NewlinePattern                = var.newline_pattern
+  PrefixFilter                  = var.prefix_filter
+  SuffixFilter                  = var.suffix_filter
+  FunctionResourceGroupName     = azurerm_resource_group.e2e.name
+  FunctionAppServicePlanType    = var.function_app_service_plan_type
+  EventHubNamespace             = azurerm_eventhub_namespace.ns.name
+  EventHubName                  = azurerm_eventhub.hub.name
+  EventHubResourceGroup         = azurerm_resource_group.e2e.name
+  BlobContainerStorageAccount   = azurerm_storage_account.blob.name
+  BlobContainerResourceGroupName = azurerm_resource_group.e2e.name
+  VirtualNetworkName            = var.virtual_network_name
+  SubnetName                    = var.subnet_name
+  VirtualNetworkResourceGroup   = var.virtual_network_resource_group
+}

--- a/tests/blobtootel/terraform/main.tf
+++ b/tests/blobtootel/terraform/main.tf
@@ -47,7 +47,7 @@ resource "azurerm_storage_account" "blob" {
 
 resource "azurerm_storage_container" "logs" {
   name                  = "logs"
-  storage_account_name   = azurerm_storage_account.blob.name
+  storage_account_name  = azurerm_storage_account.blob.name
   container_access_type = "private"
 }
 
@@ -72,28 +72,28 @@ resource "azurerm_eventgrid_event_subscription" "storage_to_eventhub" {
   name                 = "${local.name_prefix}-storage-to-eh"
   scope                = azurerm_storage_account.blob.id
   eventhub_endpoint_id = azurerm_eventhub.hub.id
-  included_event_types  = ["Microsoft.Storage.BlobCreated"]
+  included_event_types = ["Microsoft.Storage.BlobCreated"]
 }
 
 module "blobtootel" {
   source = "../../../modules/blobtootel"
 
-  OtelEndpoint                  = var.otel_endpoint
+  OtelEndpoint                   = var.otel_endpoint
   CoralogixDirectMode            = var.coralogix_direct_mode
-  CoralogixApiKey               = var.coralogix_api_key
-  CoralogixApplication          = var.coralogix_application
-  CoralogixSubsystem            = var.coralogix_subsystem
-  NewlinePattern                = var.newline_pattern
-  PrefixFilter                  = var.prefix_filter
-  SuffixFilter                  = var.suffix_filter
-  FunctionResourceGroupName     = azurerm_resource_group.e2e.name
-  FunctionAppServicePlanType    = var.function_app_service_plan_type
-  EventHubNamespace             = azurerm_eventhub_namespace.ns.name
-  EventHubName                  = azurerm_eventhub.hub.name
-  EventHubResourceGroup         = azurerm_resource_group.e2e.name
-  BlobContainerStorageAccount   = azurerm_storage_account.blob.name
+  CoralogixApiKey                = var.coralogix_api_key
+  CoralogixApplication           = var.coralogix_application
+  CoralogixSubsystem             = var.coralogix_subsystem
+  NewlinePattern                 = var.newline_pattern
+  PrefixFilter                   = var.prefix_filter
+  SuffixFilter                   = var.suffix_filter
+  FunctionResourceGroupName      = azurerm_resource_group.e2e.name
+  FunctionAppServicePlanType     = var.function_app_service_plan_type
+  EventHubNamespace              = azurerm_eventhub_namespace.ns.name
+  EventHubName                   = azurerm_eventhub.hub.name
+  EventHubResourceGroup          = azurerm_resource_group.e2e.name
+  BlobContainerStorageAccount    = azurerm_storage_account.blob.name
   BlobContainerResourceGroupName = azurerm_resource_group.e2e.name
-  VirtualNetworkName            = var.virtual_network_name
-  SubnetName                    = var.subnet_name
-  VirtualNetworkResourceGroup   = var.virtual_network_resource_group
+  VirtualNetworkName             = var.virtual_network_name
+  SubnetName                     = var.subnet_name
+  VirtualNetworkResourceGroup    = var.virtual_network_resource_group
 }

--- a/tests/blobtootel/terraform/outputs.tf
+++ b/tests/blobtootel/terraform/outputs.tf
@@ -1,0 +1,36 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "resource_group_location" {
+  value = azurerm_resource_group.e2e.location
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.blob.name
+}
+
+output "storage_account_resource_group" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "blob_container_name" {
+  value = azurerm_storage_container.logs.name
+}
+
+output "eventhub_namespace" {
+  value = azurerm_eventhub_namespace.ns.name
+}
+
+output "eventhub_name" {
+  value = azurerm_eventhub.hub.name
+}
+
+output "eventhub_resource_group" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "storage_account_connection_string" {
+  value     = azurerm_storage_account.blob.primary_connection_string
+  sensitive = true
+}

--- a/tests/blobtootel/terraform/variables.tf
+++ b/tests/blobtootel/terraform/variables.tf
@@ -1,0 +1,61 @@
+variable "otel_endpoint" {
+  description = "OTLP endpoint URL (e.g. https://ingress.eu1.coralogix.com)."
+  type        = string
+}
+
+variable "coralogix_direct_mode" {
+  type    = string
+  default = "false"
+}
+
+variable "coralogix_api_key" {
+  description = "Coralogix Send Your Data API key (when using Coralogix as OTLP endpoint)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "coralogix_application" {
+  type    = string
+  default = "azure"
+}
+
+variable "coralogix_subsystem" {
+  type    = string
+  default = "blob-storage-eventhub-e2e"
+}
+
+variable "newline_pattern" {
+  type    = string
+  default = "(?:\\r\\n|\\r|\\n)"
+}
+
+variable "prefix_filter" {
+  type    = string
+  default = "NoFilter"
+}
+
+variable "suffix_filter" {
+  type    = string
+  default = "NoFilter"
+}
+
+variable "function_app_service_plan_type" {
+  type    = string
+  default = "Consumption"
+}
+
+variable "virtual_network_name" {
+  type    = string
+  default = ""
+}
+
+variable "subnet_name" {
+  type    = string
+  default = ""
+}
+
+variable "virtual_network_resource_group" {
+  type    = string
+  default = ""
+}

--- a/tests/diagnosticdata/check_metrics.sh
+++ b/tests/diagnosticdata/check_metrics.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Poll Coralogix Data Usage API for DiagnosticData E2E app/subsystem (azure / diagnosticdata-e2e).
+# Set CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT for API host.
+
+: "${OTEL_ENDPOINT:=https://ingress.eu1.coralogix.com}"
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2"
+
+now_minus_60m() {
+  date -u -v-60M +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null || date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+SUBSYSTEM="${SUBSYSTEM:-diagnosticdata-e2e}"
+
+fetch_data_usage() {
+  local from to
+  from=$(now_minus_60m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=1h" \
+    --data-urlencode "aggregate=AGGREGATE_BY_SUBSYSTEM" \
+    -H "Authorization: Bearer ${CORALOGIX_QUERY_API_KEY:-$CORALOGIX_API_KEY}" 2>/dev/null | head -1 | \
+    jq -r --arg sub "$SUBSYSTEM" '(.result.entries // []) | map(select(any(.dimensions[]?; .genericDimension? | select(.key == "subsystem_name" and .value == $sub)))) | map(.units) | add // 0'
+}
+
+echo "Verifying data in Coralogix (app=azure, subsystem=diagnosticdata-e2e)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_data_usage)
+  echo "Data units: $count"
+  if [[ -n "$count" ]] && awk -v n="$count" 'BEGIN{exit (n+0>0)?0:1}'; then
+    echo "Metrics verified in Coralogix (data units count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No data units received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No data units yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/tests/diagnosticdata/e2e.sh
+++ b/tests/diagnosticdata/e2e.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+#
+# E2E test for DiagnosticData Terraform module.
+#
+# Order of execution:
+#   1. Deploy Terraform (RG, Event Hub, storage + diagnostic setting, function storage, DiagnosticData module).
+#   2. Upload blobs to generate storage transactions (diagnostic setting streams to Event Hub).
+#   3. Wait 2 min, then poll Coralogix Data Usage API until subsystem units > 0.
+#   4. Clean up all resources.
+#
+# Prerequisites: Azure CLI, Terraform >= 1.7.4, jq.
+# Environment: OTEL_ENDPOINT, CORALOGIX_API_KEY; optional: CORALOGIX_QUERY_API_KEY, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM, NUM_BLOBS, WAIT_INITIAL, MAX_ATTEMPTS
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+NUM_BLOBS="${NUM_BLOBS:-8}"
+
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+CUSTOM_DOMAIN="${OTEL_ENDPOINT#*://}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%/*}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%:*}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  cd "$TERRAFORM_DIR" || return 0
+  export TF_VAR_coralogix_custom_domain="${CUSTOM_DOMAIN:-}"
+  export TF_VAR_coralogix_private_key="${CORALOGIX_API_KEY:-}"
+  export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+  export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
+  export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+  terraform destroy -input=false -auto-approve 2>/dev/null || true
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Deploy Terraform (prereqs + module) ---
+log "Step 1: Deploying Terraform (RG, Event Hub, storage + diagnostic setting, DiagnosticData module)..."
+cd "$TERRAFORM_DIR"
+export TF_VAR_coralogix_custom_domain="$CUSTOM_DOMAIN"
+export TF_VAR_coralogix_private_key="$CORALOGIX_API_KEY"
+export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
+export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+
+terraform init -input=false
+
+# Apply 1: create RG and prereqs only (-refresh=false so module data sources are not evaluated yet).
+log "Step 1a: Creating RG, Event Hub, storage, diagnostic setting, function storage..."
+terraform apply -refresh=false -input=false -auto-approve \
+  -target=azurerm_resource_group.e2e \
+  -target=random_string.suffix \
+  -target=azurerm_eventhub_namespace.ns \
+  -target=azurerm_eventhub.hub \
+  -target=azurerm_eventhub_namespace_authorization_rule.listen \
+  -target=azurerm_eventhub_namespace_authorization_rule.send \
+  -target=azurerm_storage_account.diag_source \
+  -target=azurerm_storage_container.uploads \
+  -target=azurerm_monitor_diagnostic_setting.storage_to_eventhub \
+  -target=azurerm_storage_account.function
+
+# Apply 2: full apply (DiagnosticData module; data sources now find existing resources).
+log "Step 1b: Creating DiagnosticData module..."
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
+EVENTHUB_NAME=$(terraform output -raw eventhub_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+
+log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, Storage container=$CONTAINER_NAME"
+
+# --- Step 2: Upload blobs to generate storage transactions ---
+log "Step 2: Uploading $NUM_BLOBS blobs to container $CONTAINER_NAME to trigger diagnostic data..."
+PAYLOAD_FILE="${SCRIPT_DIR}/.e2e-diagdata-payload.tmp"
+printf 'e2e diagnostic data test payload - %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$PAYLOAD_FILE"
+
+uploaded=0
+for i in $(seq 1 "$NUM_BLOBS"); do
+  blob_name="e2e-diagdata-$(date +%s)-$i.txt"
+  if az storage blob upload \
+    --connection-string "$STORAGE_CONNECTION_STRING" \
+    --container-name "$CONTAINER_NAME" \
+    --name "$blob_name" \
+    --file "$PAYLOAD_FILE" \
+    --type block \
+    --content-type "text/plain" \
+    --no-progress 2>/dev/null; then
+    uploaded=$((uploaded + 1))
+  fi
+done
+rm -f "$PAYLOAD_FILE"
+
+if [[ $uploaded -eq 0 ]]; then
+  err "Step 2: No blobs uploaded. Check storage connection string and container."
+  exit 1
+fi
+log "Uploaded $uploaded blobs. Diagnostic setting will stream Transaction metric to Event Hub (may take 1–2 min)."
+
+# --- Step 3: Verify data in Coralogix (Data Usage API) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST%%/*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_DATA_USAGE_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
+
+now_minus_60m() {
+  if date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-60M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_data_usage_units() {
+  local from to
+  from=$(now_minus_60m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_DATA_USAGE_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=1h" \
+    --data-urlencode "aggregate=AGGREGATE_BY_SUBSYSTEM" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" 2>/dev/null | head -1 | \
+    jq -r --arg sub "$CX_SUBSYS" '(.result.entries // []) | map(select(any(.dimensions[]?; .genericDimension? | select(.key == "subsystem_name" and .value == $sub)))) | map(.units) | add // 0'
+}
+
+WAIT_INITIAL="${WAIT_INITIAL:-120}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-15}"
+
+log "Step 3: Waiting ${WAIT_INITIAL}s for diagnostic data to flow, then verifying data in Coralogix (subsystem=$CX_SUBSYS)..."
+sleep "$WAIT_INITIAL"
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  units=$(fetch_data_usage_units)
+  echo "Data units: $units"
+  if [[ -n "$units" ]] && awk -v n="$units" 'BEGIN{exit (n+0>0)?0:1}'; then
+    log "Step 3: Data verified in Coralogix (units=$units)."
+    break
+  fi
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 3: No data received in Coralogix after $MAX_ATTEMPTS attempts (last units=${units:-unknown})."
+    exit 1
+  fi
+  log "Step 3: No data yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 4: Clean up ---
+log "Step 4: Cleaning up resources..."
+trap - EXIT
+cd "$TERRAFORM_DIR"
+terraform destroy -input=false -auto-approve
+log "E2E test finished."

--- a/tests/diagnosticdata/terraform/main.tf
+++ b/tests/diagnosticdata/terraform/main.tf
@@ -1,0 +1,125 @@
+# E2E test: deploy Terraform DiagnosticData module (same parameters as ARM in coralogix-azure-serverless).
+# Prereqs: RG, Event Hub namespace/hub, auth rules, storage account + diagnostic setting, function storage.
+# Flow: Upload blobs → storage transactions → Diagnostic Setting streams to Event Hub → function → Coralogix.
+
+terraform {
+  required_version = ">= 1.7.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "cx-diagdata-e2e"
+  location    = "eastus"
+}
+
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+resource "azurerm_eventhub" "hub" {
+  name                = "insights-operational-logs"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "listen" {
+  name                = "diagnosticdata-e2e-listen"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = true
+  send                = false
+  manage              = false
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "send" {
+  name                = "diagnosticdata-e2e-send"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = false
+  send                = true
+  manage              = false
+}
+
+resource "azurerm_storage_account" "diag_source" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name  = azurerm_storage_account.diag_source.name
+  container_access_type = "private"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "storage_to_eventhub" {
+  name                           = "diagdata-e2e-stream-to-eventhub"
+  target_resource_id             = azurerm_storage_account.diag_source.id
+  eventhub_authorization_rule_id  = azurerm_eventhub_namespace_authorization_rule.send.id
+  eventhub_name                  = azurerm_eventhub.hub.name
+
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
+
+resource "azurerm_storage_account" "function" {
+  name                     = lower(replace("${local.name_prefix}fn${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+module "diagnosticdata" {
+  source = "../../../modules/diagnosticdata"
+
+  CoralogixRegion            = "Custom"
+  CustomDomain               = var.coralogix_custom_domain
+  CoralogixPrivateKey       = var.coralogix_private_key
+  CoralogixApplication      = var.coralogix_application
+  CoralogixSubsystem        = var.coralogix_subsystem
+  FunctionResourceGroupName  = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName = azurerm_storage_account.function.name
+  FunctionAppServicePlanType = var.function_app_service_plan_type
+  EventhubResourceGroupName  = azurerm_resource_group.e2e.name
+  EventhubNamespace          = azurerm_eventhub_namespace.ns.name
+  EventhubInstanceName       = azurerm_eventhub.hub.name
+}

--- a/tests/diagnosticdata/terraform/main.tf
+++ b/tests/diagnosticdata/terraform/main.tf
@@ -89,7 +89,7 @@ resource "azurerm_storage_container" "uploads" {
 resource "azurerm_monitor_diagnostic_setting" "storage_to_eventhub" {
   name                           = "diagdata-e2e-stream-to-eventhub"
   target_resource_id             = azurerm_storage_account.diag_source.id
-  eventhub_authorization_rule_id  = azurerm_eventhub_namespace_authorization_rule.send.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.send.id
   eventhub_name                  = azurerm_eventhub.hub.name
 
   metric {
@@ -113,9 +113,9 @@ module "diagnosticdata" {
 
   CoralogixRegion            = "Custom"
   CustomDomain               = var.coralogix_custom_domain
-  CoralogixPrivateKey       = var.coralogix_private_key
-  CoralogixApplication      = var.coralogix_application
-  CoralogixSubsystem        = var.coralogix_subsystem
+  CoralogixPrivateKey        = var.coralogix_private_key
+  CoralogixApplication       = var.coralogix_application
+  CoralogixSubsystem         = var.coralogix_subsystem
   FunctionResourceGroupName  = azurerm_resource_group.e2e.name
   FunctionStorageAccountName = azurerm_storage_account.function.name
   FunctionAppServicePlanType = var.function_app_service_plan_type

--- a/tests/diagnosticdata/terraform/outputs.tf
+++ b/tests/diagnosticdata/terraform/outputs.tf
@@ -1,0 +1,32 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "resource_group_location" {
+  value = azurerm_resource_group.e2e.location
+}
+
+output "eventhub_namespace" {
+  value = azurerm_eventhub_namespace.ns.name
+}
+
+output "eventhub_name" {
+  value = azurerm_eventhub.hub.name
+}
+
+output "eventhub_resource_group" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.diag_source.name
+}
+
+output "storage_account_connection_string" {
+  value     = azurerm_storage_account.diag_source.primary_connection_string
+  sensitive = true
+}
+
+output "blob_container_name" {
+  value = azurerm_storage_container.uploads.name
+}

--- a/tests/diagnosticdata/terraform/variables.tf
+++ b/tests/diagnosticdata/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "coralogix_custom_domain" {
+  description = "Coralogix ingress FQDN (e.g. ingress.eu2.coralogix.com), no protocol or path. Used for /azure/events/v1."
+  type        = string
+  default     = "" # Not used by destroy; set TF_VAR_* or -var for apply.
+}
+
+variable "coralogix_private_key" {
+  description = "Coralogix Send your data / Private key."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "coralogix_application" {
+  type    = string
+  default = "azure"
+}
+
+variable "coralogix_subsystem" {
+  type    = string
+  default = "diagnosticdata-e2e"
+}
+
+variable "function_app_service_plan_type" {
+  type    = string
+  default = "Consumption"
+}

--- a/tests/eventhub/check_logs.sh
+++ b/tests/eventhub/check_logs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for EventHub E2E app/subsystem (azure / eventhub-e2e).
+# Set CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT for API host.
+
+: "${OTEL_ENDPOINT:=https://ingress.eu1.coralogix.com}"
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=eventhub-e2e" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer ${CORALOGIX_QUERY_API_KEY:-$CORALOGIX_API_KEY}" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=eventhub-e2e)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/tests/eventhub/e2e.sh
+++ b/tests/eventhub/e2e.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# E2E test for EventHub Terraform module.
+#
+# Order of execution:
+#   1. Deploy Terraform (RG, Event Hub namespace/hub/consumer group/auth rules, function storage, EventHub module).
+#   2. Send test events to the Event Hub to trigger the function.
+#   3. Wait 30s, then poll Coralogix Get Logs Count API until count > 0.
+#   4. Clean up all resources.
+#
+# Prerequisites: Azure CLI, Terraform >= 1.7.4, jq, Python 3 with azure-eventhub (pip install azure-eventhub).
+# Environment: OTEL_ENDPOINT, CORALOGIX_API_KEY; optional: CORALOGIX_QUERY_API_KEY, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+# CustomDomain for EventHub module: hostname:port
+CUSTOM_DOMAIN="${OTEL_ENDPOINT#*://}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%/*}"
+if [[ "$CUSTOM_DOMAIN" != *:* ]]; then
+  CUSTOM_DOMAIN="${CUSTOM_DOMAIN}:443"
+fi
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  cd "$TERRAFORM_DIR" || return 0
+  export TF_VAR_coralogix_custom_domain="${CUSTOM_DOMAIN:-}"
+  export TF_VAR_coralogix_private_key="${CORALOGIX_API_KEY:-}"
+  export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+  export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
+  export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+  terraform destroy -input=false -auto-approve 2>/dev/null || true
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Deploy Terraform (prereqs + module) ---
+log "Step 1: Deploying Terraform (Event Hub + EventHub module)..."
+cd "$TERRAFORM_DIR"
+export TF_VAR_coralogix_custom_domain="$CUSTOM_DOMAIN"
+export TF_VAR_coralogix_private_key="$CORALOGIX_API_KEY"
+export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
+export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+
+terraform init -input=false
+
+# Apply 1: create RG and prereqs only (-refresh=false so module data sources are not evaluated yet).
+log "Step 1a: Creating RG, Event Hub namespace/hub/consumer group/auth rules, function storage..."
+terraform apply -refresh=false -input=false -auto-approve \
+  -target=azurerm_resource_group.e2e \
+  -target=random_string.suffix \
+  -target=azurerm_eventhub_namespace.ns \
+  -target=azurerm_eventhub.hub \
+  -target=azurerm_eventhub_consumer_group.coralogix \
+  -target=azurerm_eventhub_namespace_authorization_rule.listen \
+  -target=azurerm_eventhub_namespace_authorization_rule.send \
+  -target=azurerm_storage_account.function
+
+# Apply 2: full apply (EventHub module; data sources now find existing resources).
+log "Step 1b: Creating EventHub module..."
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
+EVENTHUB_NAME=$(terraform output -raw eventhub_name)
+EVENTHUB_CONSUMER_GROUP=$(terraform output -raw eventhub_consumer_group_name)
+EVENTHUB_SEND_CONNECTION_STRING=$(terraform output -raw eventhub_send_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, ConsumerGroup=$EVENTHUB_CONSUMER_GROUP"
+
+# --- Step 2: Send test events to Event Hub ---
+log "Step 2: Sending test event (JSON payload) to Event Hub..."
+TEST_MESSAGE='{"vendorID":"5","tpepPickupDateTime":1528119858000,"tpepDropoffDateTime":1528121148000,"passengerCount":2,"tripDistance":4.62,"puLocationId":"186","doLocationId":"230","rateCodeId":1,"storeAndFwdFlag":"N","paymentType":2,"fareAmount":13.5,"extra":0,"mtaTax":0.5,"improvementSurcharge":"0.3","tipAmount":2.86,"tollsAmount":0,"totalAmount":17.16}'
+if ! python3 "${SCRIPT_DIR}/send_event.py" "$EVENTHUB_SEND_CONNECTION_STRING" "$TEST_MESSAGE"; then
+  err "Failed to send event to Event Hub. Install: pip install azure-eventhub"
+  exit 1
+fi
+log "Sent test event to Event Hub: $EVENTHUB_NAMESPACE/$EVENTHUB_NAME"
+
+# --- Step 3: Verify logs in Coralogix ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST%%/*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=$CX_APP" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 3: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 3: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 3: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 3: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 4: Clean up ---
+log "Step 4: Cleaning up resources..."
+trap - EXIT
+cd "$TERRAFORM_DIR"
+terraform destroy -input=false -auto-approve
+log "E2E test finished."

--- a/tests/eventhub/requirements.txt
+++ b/tests/eventhub/requirements.txt
@@ -1,0 +1,2 @@
+# For send_event.py (E2E test)
+azure-eventhub>=5.0.0

--- a/tests/eventhub/send_event.py
+++ b/tests/eventhub/send_event.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Send a single event to an Azure Event Hub. Used by the E2E test to trigger the function.
+Requires: pip install azure-eventhub
+Usage: send_event.py <connection_string> <message_body>
+"""
+import sys
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: send_event.py <connection_string> <message_body>", file=sys.stderr)
+        sys.exit(1)
+    conn_str = sys.argv[1]
+    body = sys.argv[2]
+
+    try:
+        from azure.eventhub import EventHubProducerClient, EventData
+    except ImportError:
+        print("Install azure-eventhub: pip install azure-eventhub", file=sys.stderr)
+        sys.exit(1)
+
+    client = EventHubProducerClient.from_connection_string(conn_str)
+    try:
+        batch = client.create_batch()
+        batch.add(EventData(body))
+        client.send_batch(batch)
+    finally:
+        client.close()
+
+if __name__ == "__main__":
+    main()

--- a/tests/eventhub/terraform/main.tf
+++ b/tests/eventhub/terraform/main.tf
@@ -1,0 +1,109 @@
+# E2E test: deploy Terraform EventHub module (same parameters as ARM in coralogix-azure-serverless).
+# Prereqs: resource group, Event Hub namespace, hub, consumer group, auth rules, function app storage.
+# Step 2 in e2e.sh is replaced by this Terraform applying the module (no ARM).
+
+terraform {
+  required_version = ">= 1.7.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "cx-eventhub-e2e"
+  location    = "eastus"
+}
+
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+resource "azurerm_eventhub" "hub" {
+  name                = "logs"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_consumer_group" "coralogix" {
+  name                = "coralogix-e2e"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  eventhub_name       = azurerm_eventhub.hub.name
+  resource_group_name = azurerm_resource_group.e2e.name
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "listen" {
+  name                = "coralogix-e2e-listen"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = true
+  send                = false
+  manage              = false
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "send" {
+  name                = "e2e-send"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = false
+  send                = true
+  manage              = false
+}
+
+resource "azurerm_storage_account" "function" {
+  name                     = lower(replace("${local.name_prefix}fn${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+module "eventhub" {
+  source = "../../../modules/eventhub"
+
+  CoralogixRegion             = "Custom"
+  CustomDomain                = var.coralogix_custom_domain
+  CoralogixPrivateKey         = var.coralogix_private_key
+  CoralogixApplication       = var.coralogix_application
+  CoralogixSubsystem          = var.coralogix_subsystem
+  FunctionResourceGroupName   = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName  = azurerm_storage_account.function.name
+  FunctionAppServicePlanType  = var.function_app_service_plan_type
+  EventhubResourceGroupName   = azurerm_resource_group.e2e.name
+  EventhubNamespace           = azurerm_eventhub_namespace.ns.name
+  EventhubInstanceName        = azurerm_eventhub.hub.name
+  EventhubConsumerGroup       = azurerm_eventhub_consumer_group.coralogix.name
+  NewlinePattern              = var.newline_pattern
+  BlockingPattern             = var.blocking_pattern
+  CoralogixApplicationSelector = var.coralogix_application_selector
+  CoralogixSubsystemSelector   = var.coralogix_subsystem_selector
+}

--- a/tests/eventhub/terraform/main.tf
+++ b/tests/eventhub/terraform/main.tf
@@ -90,20 +90,20 @@ resource "azurerm_storage_account" "function" {
 module "eventhub" {
   source = "../../../modules/eventhub"
 
-  CoralogixRegion             = "Custom"
-  CustomDomain                = var.coralogix_custom_domain
-  CoralogixPrivateKey         = var.coralogix_private_key
-  CoralogixApplication       = var.coralogix_application
-  CoralogixSubsystem          = var.coralogix_subsystem
-  FunctionResourceGroupName   = azurerm_resource_group.e2e.name
-  FunctionStorageAccountName  = azurerm_storage_account.function.name
-  FunctionAppServicePlanType  = var.function_app_service_plan_type
-  EventhubResourceGroupName   = azurerm_resource_group.e2e.name
-  EventhubNamespace           = azurerm_eventhub_namespace.ns.name
-  EventhubInstanceName        = azurerm_eventhub.hub.name
-  EventhubConsumerGroup       = azurerm_eventhub_consumer_group.coralogix.name
-  NewlinePattern              = var.newline_pattern
-  BlockingPattern             = var.blocking_pattern
+  CoralogixRegion              = "Custom"
+  CustomDomain                 = var.coralogix_custom_domain
+  CoralogixPrivateKey          = var.coralogix_private_key
+  CoralogixApplication         = var.coralogix_application
+  CoralogixSubsystem           = var.coralogix_subsystem
+  FunctionResourceGroupName    = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName   = azurerm_storage_account.function.name
+  FunctionAppServicePlanType   = var.function_app_service_plan_type
+  EventhubResourceGroupName    = azurerm_resource_group.e2e.name
+  EventhubNamespace            = azurerm_eventhub_namespace.ns.name
+  EventhubInstanceName         = azurerm_eventhub.hub.name
+  EventhubConsumerGroup        = azurerm_eventhub_consumer_group.coralogix.name
+  NewlinePattern               = var.newline_pattern
+  BlockingPattern              = var.blocking_pattern
   CoralogixApplicationSelector = var.coralogix_application_selector
   CoralogixSubsystemSelector   = var.coralogix_subsystem_selector
 }

--- a/tests/eventhub/terraform/outputs.tf
+++ b/tests/eventhub/terraform/outputs.tf
@@ -1,0 +1,29 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "resource_group_location" {
+  value = azurerm_resource_group.e2e.location
+}
+
+output "eventhub_namespace" {
+  value = azurerm_eventhub_namespace.ns.name
+}
+
+output "eventhub_name" {
+  value = azurerm_eventhub.hub.name
+}
+
+output "eventhub_resource_group" {
+  value = azurerm_resource_group.e2e.name
+}
+
+output "eventhub_consumer_group_name" {
+  value = azurerm_eventhub_consumer_group.coralogix.name
+}
+
+output "eventhub_send_connection_string" {
+  value       = "${azurerm_eventhub_namespace_authorization_rule.send.primary_connection_string};EntityPath=${azurerm_eventhub.hub.name}"
+  description = "Connection string for sending events to the Event Hub (used by e2e script)."
+  sensitive   = true
+}

--- a/tests/eventhub/terraform/variables.tf
+++ b/tests/eventhub/terraform/variables.tf
@@ -1,0 +1,47 @@
+variable "coralogix_custom_domain" {
+  description = "Coralogix OTLP endpoint as hostname:port (e.g. ingress.eu1.coralogix.com:443)."
+  type        = string
+  default     = "" # Not used by destroy; set TF_VAR_* or -var for apply.
+}
+
+variable "coralogix_private_key" {
+  description = "Coralogix Send your data / Private key."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "coralogix_application" {
+  type    = string
+  default = "azure"
+}
+
+variable "coralogix_subsystem" {
+  type    = string
+  default = "eventhub-e2e"
+}
+
+variable "function_app_service_plan_type" {
+  type    = string
+  default = "Consumption"
+}
+
+variable "newline_pattern" {
+  type    = string
+  default = "(?:\\\\r\\\\n|\\\\r|\\\\n)"
+}
+
+variable "blocking_pattern" {
+  type    = string
+  default = ""
+}
+
+variable "coralogix_application_selector" {
+  type    = string
+  default = ""
+}
+
+variable "coralogix_subsystem_selector" {
+  type    = string
+  default = ""
+}

--- a/tests/storagequeue/check_logs.sh
+++ b/tests/storagequeue/check_logs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for app=azure, subsystem=storage-queue-e2e.
+# Requires: CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally CX_LOGS_COUNT_URL or OTEL_ENDPOINT.
+
+if [[ -n "${CX_LOGS_COUNT_URL:-}" ]]; then
+  :
+elif [[ -n "${OTEL_ENDPOINT:-}" ]]; then
+  CX_API_HOST="${OTEL_ENDPOINT#*://}"
+  CX_API_HOST="${CX_API_HOST%%:*}"
+  CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+  CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+else
+  CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+fi
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_SUBSYSTEM="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYSTEM" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYSTEM)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/tests/storagequeue/e2e.sh
+++ b/tests/storagequeue/e2e.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# E2E test for StorageQueue Terraform module.
+#
+# Order of execution:
+#   1. Deploy Terraform (resource group, StorageV2 + queue, function storage, and the StorageQueue module).
+#   2. Send a test payload (put a JSON message into the storage queue to trigger the function).
+#   3. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   4. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Environment variables: OTEL_ENDPOINT, CORALOGIX_API_KEY; optional: CORALOGIX_QUERY_API_KEY, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+# CustomDomain: FQDN only (no https, no path)
+CUSTOM_DOMAIN="${OTEL_ENDPOINT#*://}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%/*}"
+CUSTOM_DOMAIN="${CUSTOM_DOMAIN%%:*}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  cd "$TERRAFORM_DIR" || return 0
+  export TF_VAR_coralogix_custom_domain="${CUSTOM_DOMAIN:-}"
+  export TF_VAR_coralogix_private_key="${CORALOGIX_API_KEY:-}"
+  export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+  export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+  export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+  terraform destroy -input=false -auto-approve 2>/dev/null || true
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Deploy Terraform (prereqs + module) ---
+log "Step 1: Deploying Terraform (RG, StorageV2, queue, function storage, StorageQueue module)..."
+cd "$TERRAFORM_DIR"
+export TF_VAR_coralogix_custom_domain="$CUSTOM_DOMAIN"
+export TF_VAR_coralogix_private_key="$CORALOGIX_API_KEY"
+export TF_VAR_coralogix_application="${CORALOGIX_APPLICATION:-azure}"
+export TF_VAR_coralogix_subsystem="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+export TF_VAR_function_app_service_plan_type="${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"
+
+terraform init -input=false
+
+# Apply 1: create RG and prereqs only (-refresh=false so module data sources are not evaluated yet).
+log "Step 1a: Creating RG, storage account, queue, function storage..."
+terraform apply -refresh=false -input=false -auto-approve \
+  -target=azurerm_resource_group.e2e \
+  -target=random_string.suffix \
+  -target=azurerm_storage_account.queue \
+  -target=azurerm_storage_queue.logs \
+  -target=azurerm_storage_account.function
+
+# Apply 2: full apply (StorageQueue module; data sources now find existing resources).
+log "Step 1b: Creating StorageQueue module..."
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+STORAGE_QUEUE_NAME=$(terraform output -raw storage_queue_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Queue=$STORAGE_QUEUE_NAME"
+
+# --- Step 2: Send test payload (put JSON message into queue) ---
+log "Step 2: Putting JSON test message into storage queue to trigger the function..."
+TEST_MSG="{\"e2e\":\"storage-queue\",\"source\":\"e2e-test\",\"ts\":$(date +%s)}"
+MSG_B64=$(echo -n "$TEST_MSG" | base64)
+az storage message put \
+  --queue-name "$STORAGE_QUEUE_NAME" \
+  --content "$MSG_B64" \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --output none
+
+log "Put test message into queue: $STORAGE_QUEUE_NAME"
+
+# --- Step 3: Verify logs in Coralogix ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+CX_SUBSYSTEM="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYSTEM" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 3: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYSTEM)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 3: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 3: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 3: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 4: Clean up ---
+log "Step 4: Cleaning up resources..."
+trap - EXIT
+cd "$TERRAFORM_DIR"
+terraform destroy -input=false -auto-approve
+log "E2E test finished."

--- a/tests/storagequeue/terraform/main.tf
+++ b/tests/storagequeue/terraform/main.tf
@@ -1,0 +1,82 @@
+# E2E test: deploy Terraform StorageQueue module (same parameters as ARM in coralogix-azure-serverless).
+# Prereqs: resource group, StorageV2 account + queue, and a separate storage account for the function app.
+# Step 2 in e2e.sh is replaced by this Terraform applying the module (no ARM).
+
+terraform {
+  required_version = ">= 1.7.4"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "storagequeue-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Storage account containing the queue (StorageV2 per Coralogix docs)
+resource "azurerm_storage_account" "queue" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_queue" "logs" {
+  name                 = "coralogix-logs"
+  storage_account_name = azurerm_storage_account.queue.name
+}
+
+# Function app storage account (required by the module)
+resource "azurerm_storage_account" "function" {
+  name                     = lower(replace("${local.name_prefix}fn${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+# Deploy the Terraform module (replaces ARM deployment)
+module "storagequeue" {
+  source = "../../../modules/storagequeue"
+
+  CoralogixRegion             = "Custom"
+  CustomDomain                = var.coralogix_custom_domain
+  CoralogixPrivateKey        = var.coralogix_private_key
+  CoralogixApplication       = var.coralogix_application
+  CoralogixSubsystem         = var.coralogix_subsystem
+  FunctionResourceGroupName  = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName = azurerm_storage_account.function.name
+  FunctionAppServicePlanType = var.function_app_service_plan_type
+  StorageQueueName           = azurerm_storage_queue.logs.name
+  StorageQueueStorageAccount = azurerm_storage_account.queue.name
+  StorageQueueResourceGroupName = azurerm_resource_group.e2e.name
+}

--- a/tests/storagequeue/terraform/main.tf
+++ b/tests/storagequeue/terraform/main.tf
@@ -68,15 +68,15 @@ resource "azurerm_storage_account" "function" {
 module "storagequeue" {
   source = "../../../modules/storagequeue"
 
-  CoralogixRegion             = "Custom"
-  CustomDomain                = var.coralogix_custom_domain
-  CoralogixPrivateKey        = var.coralogix_private_key
-  CoralogixApplication       = var.coralogix_application
-  CoralogixSubsystem         = var.coralogix_subsystem
-  FunctionResourceGroupName  = azurerm_resource_group.e2e.name
-  FunctionStorageAccountName = azurerm_storage_account.function.name
-  FunctionAppServicePlanType = var.function_app_service_plan_type
-  StorageQueueName           = azurerm_storage_queue.logs.name
-  StorageQueueStorageAccount = azurerm_storage_account.queue.name
+  CoralogixRegion               = "Custom"
+  CustomDomain                  = var.coralogix_custom_domain
+  CoralogixPrivateKey           = var.coralogix_private_key
+  CoralogixApplication          = var.coralogix_application
+  CoralogixSubsystem            = var.coralogix_subsystem
+  FunctionResourceGroupName     = azurerm_resource_group.e2e.name
+  FunctionStorageAccountName    = azurerm_storage_account.function.name
+  FunctionAppServicePlanType    = var.function_app_service_plan_type
+  StorageQueueName              = azurerm_storage_queue.logs.name
+  StorageQueueStorageAccount    = azurerm_storage_account.queue.name
   StorageQueueResourceGroupName = azurerm_resource_group.e2e.name
 }

--- a/tests/storagequeue/terraform/outputs.tf
+++ b/tests/storagequeue/terraform/outputs.tf
@@ -1,0 +1,30 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for cleanup and test."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.queue.name
+  description = "Storage account name containing the queue."
+}
+
+output "storage_account_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the storage account."
+}
+
+output "storage_queue_name" {
+  value       = azurerm_storage_queue.logs.name
+  description = "Storage queue name for sending test messages."
+}
+
+output "storage_account_connection_string" {
+  value       = azurerm_storage_account.queue.primary_connection_string
+  description = "Storage account connection string for putting test messages into the queue."
+  sensitive   = true
+}

--- a/tests/storagequeue/terraform/variables.tf
+++ b/tests/storagequeue/terraform/variables.tf
@@ -1,0 +1,32 @@
+# Passed by e2e.sh via TF_VAR_ or .tfvars
+
+variable "coralogix_custom_domain" {
+  description = "Coralogix ingress FQDN (e.g. ingress.eu2.coralogix.com), no protocol or path."
+  type        = string
+  default     = "" # Not used by destroy; set TF_VAR_* or -var for apply.
+}
+
+variable "coralogix_private_key" {
+  description = "Coralogix Send your data / Private key."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "coralogix_application" {
+  description = "Coralogix application name."
+  type        = string
+  default     = "azure"
+}
+
+variable "coralogix_subsystem" {
+  description = "Coralogix subsystem name (e.g. storage-queue-e2e)."
+  type        = string
+  default     = "storage-queue-e2e"
+}
+
+variable "function_app_service_plan_type" {
+  description = "Function App service plan type."
+  type        = string
+  default     = "Consumption"
+}


### PR DESCRIPTION
# Description

Fixes CDS-2468 by implementing E2E tests for all Azure functions.

Stage 1 prepares tests themselves, makes sure they run properly locally and creates GH Workflow, merging it to master is required for any further testing.

Stage 2 will correct the GH Workflow, thus creating a CI pipeline for testing.

All tests work the same way with some function-related adjustments.

1. Deploy module-dependent resources via Terraform.
2. Deploy the Terraform module itself.
3. Put test data to the function-dependent resource.
4. Query Coralogix DataUsage API to check if data appeared in the platform
5. Signal success/failure and destroy all resources.

Requires AZ login, CX send-your-data API key and CX "normal" API key for execution. 

# How Has This Been Tested?

Ran tests locally.

# Checklist:
- [x] This change does not affect any particular component (e.g. it's readme or docs change)