### PR TITLE
fix: update indirect dependencies in BlobToOtel and EventHub

### DIFF
--- a/modules/blobtootel/main.tf
+++ b/modules/blobtootel/main.tf
@@ -128,7 +128,7 @@ resource "azurerm_linux_function_app" "blobtootel-function" {
     WEBSITE_CONTENTSHARE                     = lower(local.function_name)
     FUNCTIONS_EXTENSION_VERSION              = "~4"
     FUNCTIONS_WORKER_RUNTIME                 = "node"
-    WEBSITE_RUN_FROM_PACKAGE                 = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.2/BlobToOtel-FunctionApp.zip"
+    WEBSITE_RUN_FROM_PACKAGE                 = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.1.0/BlobToOtel-FunctionApp.zip"
   }
 }
 

--- a/modules/blobtootel/main.tf
+++ b/modules/blobtootel/main.tf
@@ -128,7 +128,7 @@ resource "azurerm_linux_function_app" "blobtootel-function" {
     WEBSITE_CONTENTSHARE                     = lower(local.function_name)
     FUNCTIONS_EXTENSION_VERSION              = "~4"
     FUNCTIONS_WORKER_RUNTIME                 = "node"
-    WEBSITE_RUN_FROM_PACKAGE                 = "https://coralogix-public.s3.eu-west-1.amazonaws.com/azure-functions-repo/BlobToOtel.zip"
+    WEBSITE_RUN_FROM_PACKAGE                 = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.2/BlobToOtel-FunctionApp.zip"
   }
 }
 

--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -112,7 +112,7 @@ resource "azurerm_linux_function_app" "eventhub-function" {
     BLOCKING_PATTERN               = var.BlockingPattern
     INCLUDE_METADATA               = tostring(var.IncludeMetadata)
     # Function App Source code - https://github.com/coralogix/coralogix-azure-serverless/tree/master/EventHub
-    WEBSITE_RUN_FROM_PACKAGE = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.0/EventHub-FunctionApp.zip"
+    WEBSITE_RUN_FROM_PACKAGE       = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.1/EventHub-FunctionApp.zip"
   }
 }
 


### PR DESCRIPTION
# Description

Solves CDS-2983 by implementing https://github.com/coralogix/coralogix-azure-serverless/pull/112 . No changelog change needed, as the package functionality wasnt changed.

# How Has This Been Tested?

locally