### PR TITLE
feat: migrate to new regional Coralogix domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.4.0
+#### **blobstorage**, **diagnosticdata**, **storagequeue**
+### 💡 Enhancements 💡
+- Updated the Coralogix ingress endpoints to the new regional domains (`coralogix.com` → `eu1.coralogix.com`, `coralogix.in` → `ap1.coralogix.com`, `coralogixsg.com` → `ap2.coralogix.com`, `coralogix.us` → `us1.coralogix.com`, `cx498.coralogix.com` → `us2.coralogix.com`)
+- Added the new region names `EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3` to `CoralogixRegion` in **diagnosticdata** and **storagequeue**, aligning them with **eventhub**
+- Added support for the `AP3` (Jakarta) region in **diagnosticdata** and **storagequeue**
+- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` remain accepted and now resolve to the new domains, so existing configurations continue to work unchanged
+
 ## v2.3.0
 #### **eventhub**
 ### 💡 Enhancements 💡

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 ## v2.4.0
-#### **blobstorage**, **diagnosticdata**, **storagequeue**
+#### **blobstorage**, **diagnosticdata**, **eventhub**, **storagequeue**
 ### 💡 Enhancements 💡
 - Updated the Coralogix ingress endpoints to the new regional domains (`coralogix.com` → `eu1.coralogix.com`, `coralogix.in` → `ap1.coralogix.com`, `coralogixsg.com` → `ap2.coralogix.com`, `coralogix.us` → `us1.coralogix.com`, `cx498.coralogix.com` → `us2.coralogix.com`)
-- Added the new region names `EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3` to `CoralogixRegion` in **diagnosticdata** and **storagequeue**, aligning them with **eventhub**
-- Added support for the `AP3` (Jakarta) region in **diagnosticdata** and **storagequeue**
-- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` remain accepted and now resolve to the new domains, so existing configurations continue to work unchanged
+- Added the new region names `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3` to `CoralogixRegion` in **diagnosticdata** and **storagequeue**, aligning them with **eventhub**
+- Added support for the `US3` region across **blobstorage**, **diagnosticdata**, **eventhub** and **storagequeue**
+- Added support for the `AP3` region in **diagnosticdata** and **storagequeue**
+- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` remain accepted in **diagnosticdata** and **storagequeue**, and now resolve to the new domains, so existing configurations continue to work unchanged
 
 ## v2.3.0
 #### **eventhub**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added the new region names `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3` to `CoralogixRegion` in **diagnosticdata** and **storagequeue**, aligning them with **eventhub**
 - Added support for the `US3` region across **blobstorage**, **diagnosticdata**, **eventhub** and **storagequeue**
 - Added support for the `AP3` region in **diagnosticdata** and **storagequeue**
-- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` remain accepted in **diagnosticdata** and **storagequeue**, and now resolve to the new domains, so existing configurations continue to work unchanged
+- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` are accepted by **diagnosticdata**, **eventhub** and **storagequeue**, and resolve to the new domains, so existing configurations continue to work unchanged
+- Restored the legacy region names in **eventhub**, which had dropped them in v2.0.0, so all three modules now accept both the current and the legacy naming
 
 ## v2.3.0
 #### **eventhub**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 - Added the new region names `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3` to `CoralogixRegion` in **diagnosticdata** and **storagequeue**, aligning them with **eventhub**
 - Added support for the `US3` region across **blobstorage**, **diagnosticdata**, **eventhub** and **storagequeue**
 - Added support for the `AP3` region in **diagnosticdata** and **storagequeue**
-- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` are accepted by **diagnosticdata**, **eventhub** and **storagequeue**, and resolve to the new domains, so existing configurations continue to work unchanged
-- Restored the legacy region names in **eventhub**, which had dropped them in v2.0.0, so all three modules now accept both the current and the legacy naming
+- The legacy region names `Europe`, `Europe2`, `India`, `Singapore`, `US` and `US2` remain accepted in **diagnosticdata** and **storagequeue**, and now resolve to the new domains, so existing configurations continue to work unchanged
 
 ## v2.3.0
 #### **eventhub**

--- a/modules/blobstorage/README.md
+++ b/modules/blobstorage/README.md
@@ -75,9 +75,10 @@ module "bloblstorage" {
 ## Coralogix regions (for OtelEndpoint)
 | Coralogix region | Example OtelEndpoint |
 |------|------------|
-| Europe | `https://ingress.coralogix.com` |
-| Europe2 | `https://ingress.eu2.coralogix.com` |
-| India | `https://ingress.coralogix.in` |
-| Singapore | `https://ingress.coralogixsg.com` |
-| US | `https://ingress.coralogix.us` |
-| US2 | `https://ingress.cx498.coralogix.com` |
+| EU1 | `https://ingress.eu1.coralogix.com` |
+| EU2 | `https://ingress.eu2.coralogix.com` |
+| US1 | `https://ingress.us1.coralogix.com` |
+| US2 | `https://ingress.us2.coralogix.com` |
+| AP1 | `https://ingress.ap1.coralogix.com` |
+| AP2 | `https://ingress.ap2.coralogix.com` |
+| AP3 | `https://ingress.ap3.coralogix.com` |

--- a/modules/blobstorage/README.md
+++ b/modules/blobstorage/README.md
@@ -79,6 +79,7 @@ module "bloblstorage" {
 | EU2 | `https://ingress.eu2.coralogix.com` |
 | US1 | `https://ingress.us1.coralogix.com` |
 | US2 | `https://ingress.us2.coralogix.com` |
+| US3 | `https://ingress.us3.coralogix.com` |
 | AP1 | `https://ingress.ap1.coralogix.com` |
 | AP2 | `https://ingress.ap2.coralogix.com` |
 | AP3 | `https://ingress.ap3.coralogix.com` |

--- a/modules/diagnosticdata/README.md
+++ b/modules/diagnosticdata/README.md
@@ -29,7 +29,7 @@ provider "azurerm" {
 module "DiagnosticData" {
   source = "coralogix/azure/coralogix//modules/DiagnosticData"
 
-  CoralogixRegion = "Europe"
+  CoralogixRegion = "EU1"
   CustomDomain = < Custom FQDN if applicable >
   CoralogixPrivateKey = < Private Key >
   CoralogixApplication = "Azure"
@@ -60,7 +60,7 @@ module "DiagnosticData" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] | `string` | `Europe` | no |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom URL for the Coralogix account. Ignore unless you have a custom URL. Just the FQDN, not the whole URL. | `string` | n/a | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application | `string` | n/a | yes |
@@ -72,12 +72,26 @@ module "DiagnosticData" {
 | <a name="input_EventhubNamespace"></a> [EventhubNamespace](#input\_EventhubNamespace) | The name of the EventHub Namespace | `string` | n/a | yes |
 | <a name="input_EventhubResourceGroupName"></a> [EventhubResourceGroupName](#input\_EventhubResourceGroupName) | The name of the resource group that the eventhub belong to. | `string` | n/a | yes |
 
-## Coralgoix regions
+## Coralogix regions
 | Coralogix region | AWS Region | Coralogix Domain |
 |------|------------|------------|
-| `Europe` |  `eu-west-1` | coralogix.com |
-| `Europe2` |  `eu-north-1` | eu2.coralogix.com |
-| `India` | `ap-south-1`  | coralogix.in |
-| `Singapore` | `ap-southeast-1` | coralogixsg.com |
-| `US` | `us-east-2` | coralogix.us |
-| `US2` | `us-west-2` | cx498.coralogix.com |
+| `EU1` | `eu-west-1` | eu1.coralogix.com |
+| `EU2` | `eu-north-1` | eu2.coralogix.com |
+| `US1` | `us-east-2` | us1.coralogix.com |
+| `US2` | `us-west-2` | us2.coralogix.com |
+| `AP1` | `ap-south-1` | ap1.coralogix.com |
+| `AP2` | `ap-southeast-1` | ap2.coralogix.com |
+| `AP3` | `ap-southeast-3` | ap3.coralogix.com |
+
+### Legacy region names
+
+The names below are deprecated but still accepted, so existing configurations keep working. New configurations should use the names above.
+
+| Legacy name | Use instead |
+|------|------------|
+| `Europe` | `EU1` |
+| `Europe2` | `EU2` |
+| `India` | `AP1` |
+| `Singapore` | `AP2` |
+| `US` | `US1` |
+| `US2` | `US2` (unchanged) |

--- a/modules/diagnosticdata/README.md
+++ b/modules/diagnosticdata/README.md
@@ -60,7 +60,7 @@ module "DiagnosticData" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom URL for the Coralogix account. Ignore unless you have a custom URL. Just the FQDN, not the whole URL. | `string` | n/a | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application | `string` | n/a | yes |
@@ -73,15 +73,16 @@ module "DiagnosticData" {
 | <a name="input_EventhubResourceGroupName"></a> [EventhubResourceGroupName](#input\_EventhubResourceGroupName) | The name of the resource group that the eventhub belong to. | `string` | n/a | yes |
 
 ## Coralogix regions
-| Coralogix region | AWS Region | Coralogix Domain |
+| Coralogix region | Cloud Region | Coralogix Domain |
 |------|------------|------------|
-| `EU1` | `eu-west-1` | eu1.coralogix.com |
-| `EU2` | `eu-north-1` | eu2.coralogix.com |
-| `US1` | `us-east-2` | us1.coralogix.com |
-| `US2` | `us-west-2` | us2.coralogix.com |
-| `AP1` | `ap-south-1` | ap1.coralogix.com |
-| `AP2` | `ap-southeast-1` | ap2.coralogix.com |
-| `AP3` | `ap-southeast-3` | ap3.coralogix.com |
+| `EU1` | AWS `eu-west-1` | eu1.coralogix.com |
+| `EU2` | AWS `eu-north-1` | eu2.coralogix.com |
+| `US1` | AWS `us-east-2` | us1.coralogix.com |
+| `US2` | AWS `us-west-2` | us2.coralogix.com |
+| `US3` | GCP `us-central1` | us3.coralogix.com |
+| `AP1` | AWS `ap-south-1` | ap1.coralogix.com |
+| `AP2` | AWS `ap-southeast-1` | ap2.coralogix.com |
+| `AP3` | AWS `ap-southeast-3` | ap3.coralogix.com |
 
 ### Legacy region names
 

--- a/modules/diagnosticdata/main.tf
+++ b/modules/diagnosticdata/main.tf
@@ -1,13 +1,23 @@
 locals {
   function_name = join("-", ["DiagnosticData", random_string.this.result])
   coralogix_regions = {
-    Europe    = "ingress.coralogix.com"
+    EU1 = "ingress.eu1.coralogix.com"
+    EU2 = "ingress.eu2.coralogix.com"
+    US1 = "ingress.us1.coralogix.com"
+    US2 = "ingress.us2.coralogix.com"
+    AP1 = "ingress.ap1.coralogix.com"
+    AP2 = "ingress.ap2.coralogix.com"
+    AP3 = "ingress.ap3.coralogix.com"
+
+    # Legacy region names, retained so existing configurations keep working. US2 is
+    # shared with the list above, so it is not repeated here.
+    Europe    = "ingress.eu1.coralogix.com"
     Europe2   = "ingress.eu2.coralogix.com"
-    India     = "ingress.coralogix.in"
-    Singapore = "ingress.coralogixsg.com"
-    US        = "ingress.coralogix.us"
-    US2       = "ingress.cx498.coralogix.com"
-    Custom    = var.CustomDomain
+    India     = "ingress.ap1.coralogix.com"
+    Singapore = "ingress.ap2.coralogix.com"
+    US        = "ingress.us1.coralogix.com"
+
+    Custom = var.CustomDomain
   }
   sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"
 }

--- a/modules/diagnosticdata/main.tf
+++ b/modules/diagnosticdata/main.tf
@@ -5,6 +5,7 @@ locals {
     EU2 = "ingress.eu2.coralogix.com"
     US1 = "ingress.us1.coralogix.com"
     US2 = "ingress.us2.coralogix.com"
+    US3 = "ingress.us3.coralogix.com"
     AP1 = "ingress.ap1.coralogix.com"
     AP2 = "ingress.ap2.coralogix.com"
     AP3 = "ingress.ap3.coralogix.com"

--- a/modules/diagnosticdata/variables.tf
+++ b/modules/diagnosticdata/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "US1", "US2", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
   }
 }
 

--- a/modules/diagnosticdata/variables.tf
+++ b/modules/diagnosticdata/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [Europe, Europe2, India, Singapore, US, US2]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
   type        = string
   validation {
-    condition     = contains(["Europe", "Europe2", "India", "Singapore", "US", "US2", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US, US2]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
   }
 }
 

--- a/modules/eventhub/README.md
+++ b/modules/eventhub/README.md
@@ -65,7 +65,7 @@ module "eventhub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta) | `string` | n/a | yes |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`] | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom OTLP endpoint for the Coralogix account. Format: hostname:port | `string` | `ingress.customsubdomain.coralogix.com:443` | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application. Supports dynamic extraction using templates `{{ $.field }}` or regex `/pattern/` | `string` | n/a | yes |
@@ -126,12 +126,13 @@ When a selector doesn't match, the function follows this fallback chain:
 3. **Default** (`coralogix-azure-eventhub` / `azure`) - Built-in defaults
 
 ## Coralogix regions
-| Coralogix region | Azure Region | Coralogix OTLP Endpoint |
+| Coralogix region | Location | Coralogix OTLP Endpoint |
 |------|------------|------------|
 | `EU1` | Ireland | ingress.eu1.coralogix.com:443 |
 | `EU2` | Stockholm | ingress.eu2.coralogix.com:443 |
 | `US1` | Ohio | ingress.us1.coralogix.com:443 |
 | `US2` | Oregon | ingress.us2.coralogix.com:443 |
+| `US3` | Iowa | ingress.us3.coralogix.com:443 |
 | `AP1` | Mumbai | ingress.ap1.coralogix.com:443 |
 | `AP2` | Singapore | ingress.ap2.coralogix.com:443 |
 | `AP3` | Jakarta | ingress.ap3.coralogix.com:443 |

--- a/modules/eventhub/README.md
+++ b/modules/eventhub/README.md
@@ -65,7 +65,7 @@ module "eventhub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`] | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom OTLP endpoint for the Coralogix account. Format: hostname:port | `string` | `ingress.customsubdomain.coralogix.com:443` | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application. Supports dynamic extraction using templates `{{ $.field }}` or regex `/pattern/` | `string` | n/a | yes |
@@ -136,16 +136,3 @@ When a selector doesn't match, the function follows this fallback chain:
 | `AP1` | Mumbai | ingress.ap1.coralogix.com:443 |
 | `AP2` | Singapore | ingress.ap2.coralogix.com:443 |
 | `AP3` | Jakarta | ingress.ap3.coralogix.com:443 |
-
-### Legacy region names
-
-The names below are deprecated but still accepted, so existing configurations keep working. New configurations should use the names above.
-
-| Legacy name | Use instead |
-|------|------------|
-| `Europe` | `EU1` |
-| `Europe2` | `EU2` |
-| `India` | `AP1` |
-| `Singapore` | `AP2` |
-| `US` | `US1` |
-| `US2` | `US2` (unchanged) |

--- a/modules/eventhub/README.md
+++ b/modules/eventhub/README.md
@@ -65,7 +65,7 @@ module "eventhub" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`] | `string` | n/a | yes |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom OTLP endpoint for the Coralogix account. Format: hostname:port | `string` | `ingress.customsubdomain.coralogix.com:443` | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application. Supports dynamic extraction using templates `{{ $.field }}` or regex `/pattern/` | `string` | n/a | yes |
@@ -136,3 +136,16 @@ When a selector doesn't match, the function follows this fallback chain:
 | `AP1` | Mumbai | ingress.ap1.coralogix.com:443 |
 | `AP2` | Singapore | ingress.ap2.coralogix.com:443 |
 | `AP3` | Jakarta | ingress.ap3.coralogix.com:443 |
+
+### Legacy region names
+
+The names below are deprecated but still accepted, so existing configurations keep working. New configurations should use the names above.
+
+| Legacy name | Use instead |
+|------|------------|
+| `Europe` | `EU1` |
+| `Europe2` | `EU2` |
+| `India` | `AP1` |
+| `Singapore` | `AP2` |
+| `US` | `US1` |
+| `US2` | `US2` (unchanged) |

--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -5,6 +5,7 @@ locals {
     EU2    = "ingress.eu2.coralogix.com:443"
     US1    = "ingress.us1.coralogix.com:443"
     US2    = "ingress.us2.coralogix.com:443"
+    US3    = "ingress.us3.coralogix.com:443"
     AP1    = "ingress.ap1.coralogix.com:443"
     AP2    = "ingress.ap2.coralogix.com:443"
     AP3    = "ingress.ap3.coralogix.com:443"
@@ -112,7 +113,7 @@ resource "azurerm_linux_function_app" "eventhub-function" {
     BLOCKING_PATTERN               = var.BlockingPattern
     INCLUDE_METADATA               = tostring(var.IncludeMetadata)
     # Function App Source code - https://github.com/coralogix/coralogix-azure-serverless/tree/master/EventHub
-    WEBSITE_RUN_FROM_PACKAGE       = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.1/EventHub-FunctionApp.zip"
+    WEBSITE_RUN_FROM_PACKAGE = "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.1/EventHub-FunctionApp.zip"
   }
 }
 

--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -1,14 +1,23 @@
 locals {
   function_name = var.FunctionAppName != "" ? var.FunctionAppName : "coralogix-eventhub-func-${random_string.this.result}"
   coralogix_regions = {
-    EU1    = "ingress.eu1.coralogix.com:443"
-    EU2    = "ingress.eu2.coralogix.com:443"
-    US1    = "ingress.us1.coralogix.com:443"
-    US2    = "ingress.us2.coralogix.com:443"
-    US3    = "ingress.us3.coralogix.com:443"
-    AP1    = "ingress.ap1.coralogix.com:443"
-    AP2    = "ingress.ap2.coralogix.com:443"
-    AP3    = "ingress.ap3.coralogix.com:443"
+    EU1 = "ingress.eu1.coralogix.com:443"
+    EU2 = "ingress.eu2.coralogix.com:443"
+    US1 = "ingress.us1.coralogix.com:443"
+    US2 = "ingress.us2.coralogix.com:443"
+    US3 = "ingress.us3.coralogix.com:443"
+    AP1 = "ingress.ap1.coralogix.com:443"
+    AP2 = "ingress.ap2.coralogix.com:443"
+    AP3 = "ingress.ap3.coralogix.com:443"
+
+    # Legacy region names, retained so existing configurations keep working. US2 is
+    # shared with the list above, so it is not repeated here.
+    Europe    = "ingress.eu1.coralogix.com:443"
+    Europe2   = "ingress.eu2.coralogix.com:443"
+    India     = "ingress.ap1.coralogix.com:443"
+    Singapore = "ingress.ap2.coralogix.com:443"
+    US        = "ingress.us1.coralogix.com:443"
+
     Custom = var.CustomDomain
   }
   sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"

--- a/modules/eventhub/main.tf
+++ b/modules/eventhub/main.tf
@@ -1,23 +1,14 @@
 locals {
   function_name = var.FunctionAppName != "" ? var.FunctionAppName : "coralogix-eventhub-func-${random_string.this.result}"
   coralogix_regions = {
-    EU1 = "ingress.eu1.coralogix.com:443"
-    EU2 = "ingress.eu2.coralogix.com:443"
-    US1 = "ingress.us1.coralogix.com:443"
-    US2 = "ingress.us2.coralogix.com:443"
-    US3 = "ingress.us3.coralogix.com:443"
-    AP1 = "ingress.ap1.coralogix.com:443"
-    AP2 = "ingress.ap2.coralogix.com:443"
-    AP3 = "ingress.ap3.coralogix.com:443"
-
-    # Legacy region names, retained so existing configurations keep working. US2 is
-    # shared with the list above, so it is not repeated here.
-    Europe    = "ingress.eu1.coralogix.com:443"
-    Europe2   = "ingress.eu2.coralogix.com:443"
-    India     = "ingress.ap1.coralogix.com:443"
-    Singapore = "ingress.ap2.coralogix.com:443"
-    US        = "ingress.us1.coralogix.com:443"
-
+    EU1    = "ingress.eu1.coralogix.com:443"
+    EU2    = "ingress.eu2.coralogix.com:443"
+    US1    = "ingress.us1.coralogix.com:443"
+    US2    = "ingress.us2.coralogix.com:443"
+    US3    = "ingress.us3.coralogix.com:443"
+    AP1    = "ingress.ap1.coralogix.com:443"
+    AP2    = "ingress.ap2.coralogix.com:443"
+    AP3    = "ingress.ap3.coralogix.com:443"
     Custom = var.CustomDomain
   }
   sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"

--- a/modules/eventhub/variables.tf
+++ b/modules/eventhub/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta)"
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]"
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "US1", "US2", "AP1", "AP2", "AP3", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, AP1, AP2, AP3, Custom]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom]."
   }
 }
 

--- a/modules/eventhub/variables.tf
+++ b/modules/eventhub/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]"
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom]."
   }
 }
 

--- a/modules/eventhub/variables.tf
+++ b/modules/eventhub/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
   }
 }
 

--- a/modules/storagequeue/README.md
+++ b/modules/storagequeue/README.md
@@ -27,7 +27,7 @@ provider "azurerm" {
 module "storagequeue" {
   source = "coralogix/azure/coralogix//modules/storagequeue"
 
-  CoralogixRegion = "Europe"
+  CoralogixRegion = "EU1"
   CustomDomain = < Custom FQDN if applicable >
   CoralogixPrivateKey = < Private Key >
   CoralogixApplication = "Azure"
@@ -58,7 +58,7 @@ module "storagequeue" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] | `string` | `Europe` | no |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom URL for the Coralogix account. Ignore unless you have a custom URL. Just the FQDN, not the whole URL. | `string` | n/a | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application | `string` | n/a | yes |
@@ -70,12 +70,26 @@ module "storagequeue" {
 | <a name="input_StorageQueueStorageAccount"></a> [StorageQueueStorageAccount](#input\_StorageQueueStorageAccount) | The name of the Storage Account containing the StorageQueue | `string` | n/a | yes |
 | <a name="input_StorageQueueResourceGroupName"></a> [StorageQueueResourceGroupName](#input\_StorageQueueResourceGroupName) | The name of the resource group that contains the Storage Account | `string` | n/a | yes |
 
-## Coralgoix regions
+## Coralogix regions
 | Coralogix region | AWS Region | Coralogix Domain |
 |------|------------|------------|
-| `Europe` |  `eu-west-1` | coralogix.com |
-| `Europe2` |  `eu-north-1` | eu2.coralogix.com |
-| `India` | `ap-south-1`  | coralogix.in |
-| `Singapore` | `ap-southeast-1` | coralogixsg.com |
-| `US` | `us-east-2` | coralogix.us |
-| `US2` | `us-west-2` | cx498.coralogix.com |
+| `EU1` | `eu-west-1` | eu1.coralogix.com |
+| `EU2` | `eu-north-1` | eu2.coralogix.com |
+| `US1` | `us-east-2` | us1.coralogix.com |
+| `US2` | `us-west-2` | us2.coralogix.com |
+| `AP1` | `ap-south-1` | ap1.coralogix.com |
+| `AP2` | `ap-southeast-1` | ap2.coralogix.com |
+| `AP3` | `ap-southeast-3` | ap3.coralogix.com |
+
+### Legacy region names
+
+The names below are deprecated but still accepted, so existing configurations keep working. New configurations should use the names above.
+
+| Legacy name | Use instead |
+|------|------------|
+| `Europe` | `EU1` |
+| `Europe2` | `EU2` |
+| `India` | `AP1` |
+| `Singapore` | `AP2` |
+| `US` | `US1` |
+| `US2` | `US2` (unchanged) |

--- a/modules/storagequeue/README.md
+++ b/modules/storagequeue/README.md
@@ -58,7 +58,7 @@ module "storagequeue" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
+| <a name="input_CoralogixRegion"></a> [CoralogixRegion](#input\_CoralogixRegion) | The Coralogix location region, possible options are [`EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`]. The legacy names [`Europe`, `Europe2`, `India`, `Singapore`, `US`, `US2`] are still accepted. | `string` | n/a | yes |
 | <a name="input_CustomDomain"></a> [CustomDomain](#input\_CustomDomain) | Your Custom URL for the Coralogix account. Ignore unless you have a custom URL. Just the FQDN, not the whole URL. | `string` | n/a | no |
 | <a name="input_CoralogixPrivateKey"></a> [CoralogixPrivateKey](#input\_CoralogixPrivateKey) | The Coralogix private key which is used to validate your authenticity | `string` | n/a | yes |
 | <a name="input_CoralogixApplication"></a> [CoralogixApplication](#input\_CoralogixApplication) | The name of your application | `string` | n/a | yes |
@@ -71,15 +71,16 @@ module "storagequeue" {
 | <a name="input_StorageQueueResourceGroupName"></a> [StorageQueueResourceGroupName](#input\_StorageQueueResourceGroupName) | The name of the resource group that contains the Storage Account | `string` | n/a | yes |
 
 ## Coralogix regions
-| Coralogix region | AWS Region | Coralogix Domain |
+| Coralogix region | Cloud Region | Coralogix Domain |
 |------|------------|------------|
-| `EU1` | `eu-west-1` | eu1.coralogix.com |
-| `EU2` | `eu-north-1` | eu2.coralogix.com |
-| `US1` | `us-east-2` | us1.coralogix.com |
-| `US2` | `us-west-2` | us2.coralogix.com |
-| `AP1` | `ap-south-1` | ap1.coralogix.com |
-| `AP2` | `ap-southeast-1` | ap2.coralogix.com |
-| `AP3` | `ap-southeast-3` | ap3.coralogix.com |
+| `EU1` | AWS `eu-west-1` | eu1.coralogix.com |
+| `EU2` | AWS `eu-north-1` | eu2.coralogix.com |
+| `US1` | AWS `us-east-2` | us1.coralogix.com |
+| `US2` | AWS `us-west-2` | us2.coralogix.com |
+| `US3` | GCP `us-central1` | us3.coralogix.com |
+| `AP1` | AWS `ap-south-1` | ap1.coralogix.com |
+| `AP2` | AWS `ap-southeast-1` | ap2.coralogix.com |
+| `AP3` | AWS `ap-southeast-3` | ap3.coralogix.com |
 
 ### Legacy region names
 

--- a/modules/storagequeue/main.tf
+++ b/modules/storagequeue/main.tf
@@ -5,6 +5,7 @@ locals {
     EU2 = "ingress.eu2.coralogix.com"
     US1 = "ingress.us1.coralogix.com"
     US2 = "ingress.us2.coralogix.com"
+    US3 = "ingress.us3.coralogix.com"
     AP1 = "ingress.ap1.coralogix.com"
     AP2 = "ingress.ap2.coralogix.com"
     AP3 = "ingress.ap3.coralogix.com"

--- a/modules/storagequeue/main.tf
+++ b/modules/storagequeue/main.tf
@@ -1,13 +1,23 @@
 locals {
   function_name = join("-", ["StorageQueue", substr(var.StorageQueueName, 0, 27), random_string.this.result])
   coralogix_regions = {
-    Europe    = "ingress.coralogix.com"
+    EU1 = "ingress.eu1.coralogix.com"
+    EU2 = "ingress.eu2.coralogix.com"
+    US1 = "ingress.us1.coralogix.com"
+    US2 = "ingress.us2.coralogix.com"
+    AP1 = "ingress.ap1.coralogix.com"
+    AP2 = "ingress.ap2.coralogix.com"
+    AP3 = "ingress.ap3.coralogix.com"
+
+    # Legacy region names, retained so existing configurations keep working. US2 is
+    # shared with the list above, so it is not repeated here.
+    Europe    = "ingress.eu1.coralogix.com"
     Europe2   = "ingress.eu2.coralogix.com"
-    India     = "ingress.coralogix.in"
-    Singapore = "ingress.coralogixsg.com"
-    US        = "ingress.coralogix.us"
-    US2       = "ingress.cx498.coralogix.com"
-    Custom    = var.CustomDomain
+    India     = "ingress.ap1.coralogix.com"
+    Singapore = "ingress.ap2.coralogix.com"
+    US        = "ingress.us1.coralogix.com"
+
+    Custom = var.CustomDomain
   }
   sku = var.FunctionAppServicePlanType == "Consumption" ? "Y1" : "EP1"
 }

--- a/modules/storagequeue/variables.tf
+++ b/modules/storagequeue/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, US3, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
   type        = string
   validation {
-    condition     = contains(["EU1", "EU2", "US1", "US2", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "US3", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, US3, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
   }
 }
 

--- a/modules/storagequeue/variables.tf
+++ b/modules/storagequeue/variables.tf
@@ -1,9 +1,9 @@
 variable "CoralogixRegion" {
-  description = "The Coralogix location region, possible options are [Europe, Europe2, India, Singapore, US, US2]"
+  description = "The Coralogix location region, possible options are [EU1, EU2, US1, US2, AP1, AP2, AP3]. The legacy names [Europe, Europe2, India, Singapore, US, US2] are still accepted."
   type        = string
   validation {
-    condition     = contains(["Europe", "Europe2", "India", "Singapore", "US", "US2", "Custom"], var.CoralogixRegion)
-    error_message = "The coralogix region must be on of these values: [Europe, Europe2, India, Singapore, US, US2]."
+    condition     = contains(["EU1", "EU2", "US1", "US2", "AP1", "AP2", "AP3", "Europe", "Europe2", "India", "Singapore", "US", "Custom"], var.CoralogixRegion)
+    error_message = "The coralogix region must be one of these values: [EU1, EU2, US1, US2, AP1, AP2, AP3, Custom], or a legacy name [Europe, Europe2, India, Singapore, US, US2]."
   }
 }
 

--- a/tests/blobstorage/e2e.sh
+++ b/tests/blobstorage/e2e.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"

--- a/tests/blobtootel/e2e.sh
+++ b/tests/blobtootel/e2e.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
 

--- a/tests/diagnosticdata/e2e.sh
+++ b/tests/diagnosticdata/e2e.sh
@@ -24,7 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 NUM_BLOBS="${NUM_BLOBS:-8}"
 
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"

--- a/tests/storagequeue/e2e.sh
+++ b/tests/storagequeue/e2e.sh
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 
 # Required
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"


### PR DESCRIPTION
# Description

Migrates the legacy Coralogix ingress domains to the new regional domains and adds the missing `US3` region, without changing the behaviour of any configuration that works today.

**Domain mapping applied:**

| Legacy | New |
|---|---|
| `coralogix.com` | `eu1.coralogix.com` |
| `eu2.coralogix.com` | `eu2.coralogix.com` (unchanged) |
| `coralogix.us` | `us1.coralogix.com` |
| `cx498.coralogix.com` | `us2.coralogix.com` |
| `coralogix.in` | `ap1.coralogix.com` |
| `coralogixsg.com` | `ap2.coralogix.com` |
| `ap3.coralogix.com` | `ap3.coralogix.com` (unchanged) |

Existing subdomains are preserved, so `ingress.` prefixes carry over (e.g. `ingress.cx498.coralogix.com` → `ingress.us2.coralogix.com`).

Reference: [Coralogix domain docs](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/)

## Backward compatibility

`diagnosticdata` and `storagequeue` gain the new region names `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`, matching the names `eventhub` already uses. **Their existing legacy names are kept**, in the region map *and* in the `contains()` validation, and now resolve to the new domains:

| Legacy name | Resolves same as |
|---|---|
| `Europe` | `EU1` |
| `Europe2` | `EU2` |
| `India` | `AP1` |
| `Singapore` | `AP2` |
| `US` | `US1` |
| `US2` | `US2` (unchanged) |

Widening the validation matters as much as adding the map keys — without it, `contains()` would still reject `AP1`.

This PR does not reinstate region names that earlier releases removed on purpose: `eventhub` dropped the legacy names in v2.0.0 and `blobstorage` replaced `CoralogixRegion` with `OtelEndpoint` in #33. Those stay as they are. The guarantee here is narrower and stricter — **this PR removes nothing itself**, verified below.

## New regions

- **`US3`** was missing from *every* module, `eventhub` included, so it has been added across all four. Note it runs on **GCP `us-central1` (Iowa)**, not AWS — which is why the region-table column in the `diagnosticdata`/`storagequeue` READMEs is renamed `AWS Region` → `Cloud Region`, with the provider named per row.
- **`AP3`** is now selectable in `diagnosticdata` and `storagequeue` for the first time.

# How Has This Been Tested?

- **Nothing was dropped.** Diffed the region map keys and the `contains()` allow-list of every module against `master`: `eventhub` 8→9, `diagnosticdata` 7→14, `storagequeue` 7→14, with **zero** names removed in any of them — each is a strict superset of `master`. Also reviewed every removed line across all `.tf` files: each is a legacy *domain value* being replaced (its key survives), a description/validation string being widened, or `fmt` realignment.
- **Alias equivalence** — extracted the real maps into a standalone config and ran `terraform apply`. All six legacy names resolve to the same endpoint as their new name (`Europe==EU1`, `Europe2==EU2`, `India==AP1`, `Singapore==AP2`, `US==US1`, `US2==US2`) → all `true`.
- **Map ↔ validation cross-check** — `diagnosticdata` 14/14, `storagequeue` 14/14, `eventhub` 9/9; exact match both directions, no duplicate keys. Nothing is accepted-but-unmapped (which would yield a null endpoint) or mapped-but-rejected.
- `terraform fmt -check -recursive` and `terraform init -backend=false && terraform validate` pass for all three modules.
- `bash -n` clean on the four modified `e2e.sh` scripts (example strings in `OTEL_ENDPOINT` guards only, no logic).
- Repo-wide grep confirms no `coralogix.us` / `coralogix.in` / `coralogixsg` / `cx498` references remain, and that every region list includes `US3`.

Not run: the e2e suites need live Azure + Coralogix credentials.

**Deliberately left alone:** the `info@coralogix.com` address in `AUTHORS.md`, the `https://coralogix.com/docs/` link in `examples/eventhub/README.md`, and the `ingress.customsubdomain.coralogix.com` placeholders (a stand-in for a customer's own custom domain, not a regional one).

**Incidental fixes**, all inside blocks already being edited and easy to drop if unwanted:
- The `CoralogixRegion` docs row claimed Default `Europe` / Required `no`, but neither `variables.tf` defines a default — corrected to `n/a` / `yes`.
- `## Coralgoix regions` heading typo (nothing links to that anchor).
- `eventhub`'s region column was headed `Azure Region` while listing Coralogix cluster locations — renamed to `Location`.
- `terraform fmt` on `modules/eventhub/main.tf`, which had a pre-existing alignment violation on `WEBSITE_RUN_FROM_PACKAGE` (present on `master`, unrelated to this change — fixed only because this PR pulls `eventhub` into the Terraform CI job, where it would otherwise surface as a format failure attributed to this PR).

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)